### PR TITLE
Physiboss v3

### DIFF
--- a/bin/cell_def_tab.py
+++ b/bin/cell_def_tab.py
@@ -3438,8 +3438,8 @@ class CellDef(QWidget):
     def physiboss_clicked_add_initial_value(self):
         self.physiboss_add_initial_values()
         self.param_d[self.current_cell_def]["intracellular"]["initial_values"].append({
-            'node': None,
-            'value': None
+            'node': self.param_d[self.current_cell_def]["intracellular"]["list_nodes"][0],
+            'value': ""
         })
 
     def physiboss_add_initial_values(self):
@@ -3504,8 +3504,8 @@ class CellDef(QWidget):
     def physiboss_clicked_add_mutant(self):
         self.physiboss_add_mutant()
         self.param_d[self.current_cell_def]["intracellular"]["mutants"].append({
-            'node': '',
-            'value': '',
+            'node': self.param_d[self.current_cell_def]["intracellular"]["list_nodes"][0],
+            'value': "",
         })
 
     def physiboss_add_mutant(self):
@@ -3569,8 +3569,8 @@ class CellDef(QWidget):
     def physiboss_clicked_add_parameter(self):
         self.physiboss_add_parameter()
         self.param_d[self.current_cell_def]["intracellular"]["parameters"].append({
-            'name': None,
-            'value': None
+            'name': self.param_d[self.current_cell_def]["intracellular"]["list_parameters"][0],
+            'value': ""
         })
 
     def physiboss_add_parameter(self):
@@ -3633,12 +3633,12 @@ class CellDef(QWidget):
     def physiboss_clicked_add_input(self):
         self.physiboss_add_input()
         self.param_d[self.current_cell_def]["intracellular"]["inputs"].append({
-            'name': '',
-            'node': '',
+            'name': self.physiboss_signals[0],
+            'node': self.param_d[self.current_cell_def]["intracellular"]["list_nodes"][0],
             'action': 'activation',
-            'threshold': 1.0,
-            'inact_threshold': 1.0,
-            'smoothing': 0
+            'threshold': "",
+            'inact_threshold': "",
+            'smoothing': ""
         })
 
     def physiboss_add_input(self):
@@ -3758,12 +3758,12 @@ class CellDef(QWidget):
     def physiboss_clicked_add_output(self):
         self.physiboss_add_output()
         self.param_d[self.current_cell_def]["intracellular"]["outputs"].append({
-            'name': '',
-            'node': '',
+            'name': self.physiboss_behaviours[0],
+            'node': self.param_d[self.current_cell_def]["intracellular"]["list_nodes"][0],
             'action': 'activation',
-            'value': 1.0,
-            'basal_value': 1.0,
-            'smoothing': 0
+            'value': "",
+            'basal_value': "",
+            'smoothing': ""
         })
 
     def physiboss_add_output(self):

--- a/bin/cell_def_tab.py
+++ b/bin/cell_def_tab.py
@@ -6697,6 +6697,14 @@ class CellDef(QWidget):
         cdname = self.current_cell_def
         if self.param_d[cdname]["intracellular"] is not None:
             if self.param_d[cdname]["intracellular"]["type"] == "maboss":
+                
+                self.physiboss_clear_initial_values()
+                self.physiboss_clear_mutants()
+                self.physiboss_clear_parameters()
+                self.physiboss_clear_node_inheritance()
+                self.physiboss_clear_inputs()
+                self.physiboss_clear_outputs()
+
                 self.intracellular_type_dropdown.setCurrentIndex(1)
                 if "bnd_filename" in self.param_d[cdname]["intracellular"].keys(): 
                     self.physiboss_bnd_file.setText(self.param_d[cdname]["intracellular"]["bnd_filename"])
@@ -6708,12 +6716,6 @@ class CellDef(QWidget):
                 self.physiboss_starttime.setText(self.param_d[cdname]["intracellular"]["start_time"])
                 self.physiboss_global_inheritance_checkbox.setChecked(self.param_d[cdname]["intracellular"]["global_inheritance"] == "True")
 
-                self.physiboss_clear_initial_values()
-                self.physiboss_clear_mutants()
-                self.physiboss_clear_parameters()
-                self.physiboss_clear_node_inheritance()
-                self.physiboss_clear_inputs()
-                self.physiboss_clear_outputs()
                 self.fill_substrates_comboboxes()
                 self.fill_celltypes_comboboxes()
                 self.physiboss_update_list_signals()


### PR DESCRIPTION
Fix the bug when creating new mutants (or any new element with a dropdown actually), then changing cell def, and coming back to the previous one.
Also changed the order of things when changing a new cell def : first clearing all the forms, then loading the new model, getting the list of nodes and parameters, and then loading the new forms. 