### PR TITLE
Physiboss Update

### DIFF
--- a/bin/cell_def_tab.py
+++ b/bin/cell_def_tab.py
@@ -3298,7 +3298,7 @@ class CellDef(QWidget):
     def physiboss_update_list_nodes(self):
 
         t_intracellular = self.param_d[self.current_cell_def]["intracellular"]
-        print(f'----- {inspect.stack()[0][3]}: {t_intracellular}')
+        
         if t_intracellular is not None:
 
             # Here I started by looking at both the bnd and the cfg
@@ -3334,7 +3334,6 @@ class CellDef(QWidget):
                         self.param_d[self.current_cell_def]["intracellular"]["initial_values"][i]["node"] = ""
                         node.setCurrentIndex(-1)
 
-                print("_mutants= ",self.physiboss_mutants)
                 for i, (node, _, _, _) in enumerate(self.physiboss_mutants):
                     node.currentIndexChanged.disconnect()
                     node.clear()
@@ -3342,8 +3341,6 @@ class CellDef(QWidget):
                         node.addItem(name)
                     node.currentIndexChanged.connect(lambda index: self.physiboss_mutants_node_changed(i, index))
 
-                    print("  ['mutants']= ",self.param_d[self.current_cell_def]["intracellular"]["mutants"])
-                    print("  >> i= ",i)
                     if (self.param_d[self.current_cell_def]["intracellular"]["mutants"][i]["node"] is not None
                         and self.param_d[self.current_cell_def]["intracellular"]["mutants"][i]["node"] in list_nodes
                     ):

--- a/bin/vis_tab.py
+++ b/bin/vis_tab.py
@@ -1602,7 +1602,10 @@ class Vis(QWidget):
         self.cells_svg_rb.setEnabled(bval)
         self.cells_mat_rb.setEnabled(bval)
         self.cells_edge_checkbox.setEnabled(bval)
-
+        
+        if self.physiboss_vis_checkbox is not None:
+            self.physiboss_vis_checkbox.setEnabled(bval)
+            
         if not self.cells_checked_flag:
             self.cell_scalar_combobox.setEnabled(False)
             if self.cax2:

--- a/bin/vis_tab.py
+++ b/bin/vis_tab.py
@@ -231,7 +231,7 @@ class Vis(QWidget):
 
         # self.config_file = "mymodel.xml"
         self.physiboss_node_dict = {}
-        
+        self.physiboss_previous_node = None
         self.reset_model_flag = True
         self.xmin = -80
         self.xmax = 80
@@ -1000,7 +1000,19 @@ class Vis(QWidget):
     def physiboss_vis_cell_type_cb(self, idx):
         if idx >= 0:
             self.physiboss_selected_cell_line = idx
+            self.physiboss_previous_node = self.physiboss_selected_node
+            self.physiboss_node_combobox.disconnect()
             self.fill_physiboss_nodes_combobox(self.physiboss_node_dict[list(self.physiboss_node_dict.keys())[idx]])
+            if self.physiboss_previous_node is not None and self.physiboss_previous_node in self.physiboss_node_dict[list(self.physiboss_node_dict.keys())[self.physiboss_selected_cell_line]]:
+                node_ind = self.physiboss_node_dict[list(self.physiboss_node_dict.keys())[self.physiboss_selected_cell_line]].index(self.physiboss_previous_node)
+                self.physiboss_node_combobox.setCurrentIndex(node_ind)
+                self.physiboss_selected_node = self.physiboss_previous_node
+                self.physiboss_previous_node = None
+            else:
+                self.physiboss_node_combobox.setCurrentIndex(0)
+                self.physiboss_selected_node = self.physiboss_node_dict[list(self.physiboss_node_dict.keys())[self.physiboss_selected_cell_line]][0]
+                
+            self.physiboss_node_combobox.currentIndexChanged.connect(self.physiboss_vis_node_cb)
             self.update_plots()
             
     def physiboss_vis_node_cb(self, idx):

--- a/bin/vis_tab.py
+++ b/bin/vis_tab.py
@@ -232,6 +232,7 @@ class Vis(QWidget):
         # self.config_file = "mymodel.xml"
         self.physiboss_node_dict = {}
         self.physiboss_previous_node = None
+        self.physiboss_previous_cells = None
         self.reset_model_flag = True
         self.xmin = -80
         self.xmax = 80
@@ -929,7 +930,7 @@ class Vis(QWidget):
             
             self.physiboss_vis_checkbox = QCheckBox('Color by PhysiBoSS node state')
             self.physiboss_vis_flag = False
-            self.physiboss_vis_checkbox.setEnabled(not self.plot_cells_svg)
+            self.physiboss_vis_checkbox.setEnabled(True)
             self.physiboss_vis_checkbox.setChecked(self.physiboss_vis_flag)
             self.physiboss_vis_checkbox.clicked.connect(self.physiboss_vis_toggle_cb)
             self.physiboss_hbox_1.addWidget(self.physiboss_vis_checkbox)
@@ -993,8 +994,25 @@ class Vis(QWidget):
         self.physiboss_cell_type_combobox.setEnabled(bval)
         self.physiboss_node_combobox.setEnabled(bval)
         self.physiboss_population_counts_button.setEnabled(bval)
-        self.cell_scalar_combobox.setEnabled(not bval)
-        self.cell_scalar_cbar_combobox.setEnabled(not bval)
+        
+        if bval:
+            self.physiboss_previous_cells = self.plot_cells_svg
+            self.plot_cells_svg = False
+            self.custom_button.setEnabled(False)
+            self.cells_svg_rb.setChecked(False)
+            self.cells_mat_rb.setChecked(True)
+            self.cell_scalar_combobox.setEnabled(False)
+            self.cell_scalar_cbar_combobox.setEnabled(False)
+        
+            
+        else:
+            self.plot_cells_svg = self.physiboss_previous_cells
+            self.custom_button.setEnabled(not self.plot_cells_svg)
+            self.cells_svg_rb.setChecked(self.plot_cells_svg)
+            self.cells_mat_rb.setChecked(not self.plot_cells_svg)
+            self.cell_scalar_combobox.setEnabled(not self.plot_cells_svg)
+            self.cell_scalar_cbar_combobox.setEnabled(not not self.plot_cells_svg)
+           
         self.update_plots()
         
     def physiboss_vis_cell_type_cb(self, idx):
@@ -1157,7 +1175,7 @@ class Vis(QWidget):
             self.cell_scalar_combobox.setEnabled(False)
             self.cell_scalar_cbar_combobox.setEnabled(False)
             if self.physiboss_vis_checkbox is not None:
-                self.physiboss_vis_checkbox.setEnabled(False)
+                self.physiboss_vis_checkbox.setChecked(False)
             # self.fix_cmap_checkbox.setEnabled(bval)
 
             if self.cax2:

--- a/bin/vis_tab.py
+++ b/bin/vis_tab.py
@@ -969,14 +969,15 @@ class Vis(QWidget):
         self.update_plots()
         
     def physiboss_vis_cell_type_cb(self, idx):
-        if idx > 0:
-            self.fill_physiboss_nodes_combobox(self.physiboss_node_dict[list(self.physiboss_node_dict.keys())[idx]])
+        if idx >= 0:
             self.physiboss_selected_cell_line = idx
+            self.fill_physiboss_nodes_combobox(self.physiboss_node_dict[list(self.physiboss_node_dict.keys())[idx]])
             self.update_plots()
             
     def physiboss_vis_node_cb(self, idx):
-        self.physiboss_selected_node = self.physiboss_node_dict[list(self.physiboss_node_dict.keys())[self.physiboss_selected_cell_line]][idx]
-        self.update_plots()
+        if idx >= 0:
+            self.physiboss_selected_node = self.physiboss_node_dict[list(self.physiboss_node_dict.keys())[self.physiboss_selected_cell_line]][idx]
+            self.update_plots()
         
     def output_folder_cb(self):
         print(f"output_folder_cb(): old={self.output_dir}")

--- a/bin/vis_tab.py
+++ b/bin/vis_tab.py
@@ -617,6 +617,7 @@ class Vis(QWidget):
 
         self.physiboss_cell_type_combobox = None
         self.physiboss_node_combobox = None
+        self.physiboss_population_counts_button = None
         #-----------
         self.frame_count.textChanged.connect(self.change_frame_count_cb)
 
@@ -931,7 +932,14 @@ class Vis(QWidget):
             self.physiboss_hbox_2.addWidget(self.physiboss_node_combobox)
 
             self.vbox.addLayout(self.physiboss_hbox_2)
-        
+       
+            #------------------
+            self.physiboss_population_counts_button = QPushButton("Boolean states plot")
+            # self.cell_counts_button.setStyleSheet("QPushButton {background-color: lightgreen; color: black;}")
+            self.physiboss_population_counts_button.setFixedWidth(200)
+            self.physiboss_population_counts_button.clicked.connect(self.physiboss_state_counts_cb)
+            self.vbox.addWidget(self.physiboss_population_counts_button)
+
     def physiboss_vis_hide(self):
         print("\n--------- physiboss_vis_hide()")
 
@@ -948,6 +956,9 @@ class Vis(QWidget):
             self.physiboss_node_combobox.deleteLater()
 
             self.physiboss_hbox_2.deleteLater()
+            
+            self.physiboss_population_counts_button.disconnect()
+            self.physiboss_population_counts_button.deleteLater()
 
     def fill_physiboss_cell_types_combobox(self, cell_types):
         self.physiboss_cell_type_combobox.clear()
@@ -964,6 +975,7 @@ class Vis(QWidget):
         self.physiboss_vis_flag = bval
         self.physiboss_cell_type_combobox.setEnabled(bval)
         self.physiboss_node_combobox.setEnabled(bval)
+        self.physiboss_population_counts_button.setEnabled(bval)
         self.cell_scalar_combobox.setEnabled(not bval)
         self.cell_scalar_cbar_combobox.setEnabled(not bval)
         self.update_plots()
@@ -978,6 +990,93 @@ class Vis(QWidget):
         if idx >= 0:
             self.physiboss_selected_node = self.physiboss_node_dict[list(self.physiboss_node_dict.keys())[self.physiboss_selected_cell_line]][idx]
             self.update_plots()
+
+
+    def physiboss_state_counts_cb(self):
+        print("---- cell_counts_cb(): --> window for 2D population plots")
+        # self.analysis_data_wait.value = 'compute n of N ...'
+
+        if not self.get_cell_types_from_legend():
+            if not self.get_cell_types_from_config():
+                return
+
+        xml_pattern = self.output_dir + "/" + "output*.xml"
+        xml_files = glob.glob(xml_pattern)
+        
+        num_xml = len(xml_files)
+        if num_xml == 0:
+            print("last_plot_cb(): WARNING: no output*.xml files present")
+            msgBox = QMessageBox()
+            msgBox.setIcon(QMessageBox.Information)
+            msgBox.setText("Could not find any " + self.output_dir + "/output*.xml")
+            msgBox.setStandardButtons(QMessageBox.Ok)
+            msgBox.exec()
+            return
+
+        xml_files.sort()
+        
+        print("PhysiBoSS selected celltype = ", self.physiboss_selected_cell_line)
+        cell_def_name = list(self.physiboss_node_dict.keys())[self.physiboss_selected_cell_line]
+        all_states = set()
+        states_pops = []
+        mcds = []
+        for i_frame, fname in enumerate(xml_files):
+            basename = os.path.basename(fname)
+            t_mcds = pyMCDS(basename, self.output_dir, microenv=False, graph=False, verbose=False)
+            mcds.append(t_mcds)
+            
+            try:
+                cell_types = t_mcds.get_cell_df()["cell_type"]
+            except:
+                print("vis_tab.py: physiboss_state_counts_cb(): error performing mcds.get_cell_df()['cell_type']")
+                return
+            
+            
+            physiboss_state_file = os.path.join(self.output_dir, "states_%08d.csv" % i_frame)
+            
+            if not Path(physiboss_state_file).is_file():
+                print("vis_tab.py: physiboss_state_counts_cb(): error file not found ",physiboss_state_file)
+                return
+            
+            states_pop = {}
+            with open(physiboss_state_file, newline='') as csvfile:
+                states_reader = csv.reader(csvfile, delimiter=',')
+                for row in states_reader:
+                    if row[0] != 'ID':
+                        ID = int(row[0])
+                        if cell_types[ID] == self.physiboss_selected_cell_line:
+                            if row[1] in states_pop.keys():
+                                states_pop[row[1]] += 1
+                            else:
+                                states_pop[row[1]] = 1
+            
+            states_pops.append(states_pop)
+            all_states = all_states.union(set(states_pop.keys()))
+        
+        pop_data = np.zeros((len(xml_files), len(all_states)))
+        states_index = {state:i for i, state in enumerate(all_states)}
+        for i_frame, fname in enumerate(xml_files):
+            for state, pop in states_pops[i_frame].items():
+                pop_data[i_frame, states_index[state]] = pop
+                
+            
+
+        tval = np.linspace(0, mcds[-1].get_time(), len(xml_files))
+        if not self.population_plot:
+            self.population_plot = PopulationPlotWindow()
+
+        self.population_plot.ax0.cla()
+        self.population_plot.ax0.plot(tval, pop_data, label=states_index.keys())
+
+
+        self.population_plot.ax0.set_xlabel('time (mins)')
+        self.population_plot.ax0.set_ylabel('# of cells')
+        self.population_plot.ax0.set_title("PhysiBoSS state populations of cell line " + cell_def_name, fontsize=10)
+        self.population_plot.ax0.legend(loc='center right', prop={'size': 8})
+        self.population_plot.canvas.update()
+        self.population_plot.canvas.draw()
+        self.population_plot.show()
+
         
     def output_folder_cb(self):
         print(f"output_folder_cb(): old={self.output_dir}")

--- a/bin/vis_tab.py
+++ b/bin/vis_tab.py
@@ -150,6 +150,21 @@ class PopulationPlotWindow(QWidget):
         self.layout.addWidget(self.canvas)
         self.setLayout(self.layout)
 
+class PhysiBoSSStatesPopulationPlotWindow(QWidget):
+    def __init__(self):
+        super().__init__()
+        self.layout = QVBoxLayout()
+        self.label = QLabel("PhysiBoSS states populations")
+        # self.layout.addWidget(self.label)
+
+        self.figure = plt.figure()
+        self.canvas = FigureCanvasQTAgg(self.figure)
+        self.canvas.setStyleSheet("background-color:transparent;")
+        self.ax0 = self.figure.add_subplot(111, adjustable='box')
+        self.layout.addWidget(self.canvas)
+        self.setLayout(self.layout)
+
+
 class QHLine(QFrame):
     def __init__(self):
         super(QHLine, self).__init__()
@@ -174,6 +189,7 @@ class Vis(QWidget):
         self.bgcolor = [1,1,1,1]  # all 1.0 for white 
 
         self.population_plot = None
+        self.physiboss_population_plot = None
         self.celltype_name = []
         self.celltype_color = []
 
@@ -937,6 +953,7 @@ class Vis(QWidget):
             self.physiboss_population_counts_button = QPushButton("Boolean states plot")
             # self.cell_counts_button.setStyleSheet("QPushButton {background-color: lightgreen; color: black;}")
             self.physiboss_population_counts_button.setFixedWidth(200)
+            self.physiboss_population_counts_button.setEnabled(False)
             self.physiboss_population_counts_button.clicked.connect(self.physiboss_state_counts_cb)
             self.vbox.addWidget(self.physiboss_population_counts_button)
 
@@ -993,13 +1010,8 @@ class Vis(QWidget):
 
 
     def physiboss_state_counts_cb(self):
-        print("---- cell_counts_cb(): --> window for 2D population plots")
-        # self.analysis_data_wait.value = 'compute n of N ...'
-
-        if not self.get_cell_types_from_legend():
-            if not self.get_cell_types_from_config():
-                return
-
+        print("---- physiboss_state_counts_cb(): --> window for 2D physiboss state population plots")
+        
         xml_pattern = self.output_dir + "/" + "output*.xml"
         xml_files = glob.glob(xml_pattern)
         
@@ -1015,7 +1027,6 @@ class Vis(QWidget):
 
         xml_files.sort()
         
-        print("PhysiBoSS selected celltype = ", self.physiboss_selected_cell_line)
         cell_def_name = list(self.physiboss_node_dict.keys())[self.physiboss_selected_cell_line]
         all_states = set()
         states_pops = []
@@ -1062,20 +1073,20 @@ class Vis(QWidget):
             
 
         tval = np.linspace(0, mcds[-1].get_time(), len(xml_files))
-        if not self.population_plot:
-            self.population_plot = PopulationPlotWindow()
+        if not self.physiboss_population_plot:
+            self.physiboss_population_plot = PhysiBoSSStatesPopulationPlotWindow()
 
-        self.population_plot.ax0.cla()
-        self.population_plot.ax0.plot(tval, pop_data, label=states_index.keys())
+        self.physiboss_population_plot.ax0.cla()
+        self.physiboss_population_plot.ax0.plot(tval, pop_data, label=states_index.keys())
 
 
-        self.population_plot.ax0.set_xlabel('time (mins)')
-        self.population_plot.ax0.set_ylabel('# of cells')
-        self.population_plot.ax0.set_title("PhysiBoSS state populations of cell line " + cell_def_name, fontsize=10)
-        self.population_plot.ax0.legend(loc='center right', prop={'size': 8})
-        self.population_plot.canvas.update()
-        self.population_plot.canvas.draw()
-        self.population_plot.show()
+        self.physiboss_population_plot.ax0.set_xlabel('time (mins)')
+        self.physiboss_population_plot.ax0.set_ylabel('# of cells')
+        self.physiboss_population_plot.ax0.set_title("PhysiBoSS state populations of cell line " + cell_def_name, fontsize=10)
+        self.physiboss_population_plot.ax0.legend(loc='center right', prop={'size': 8})
+        self.physiboss_population_plot.canvas.update()
+        self.physiboss_population_plot.canvas.draw()
+        self.physiboss_population_plot.show()
 
         
     def output_folder_cb(self):


### PR DESCRIPTION
- Fixed a bug in the selection of the cell definition in physiboss visualization (1st one wasn't working)
- First draft of a boolean state populations count graph
- Now trying to keep the same node selected when changing cell def (if such a node exists)
- PhysiBoSS visualization can be checked whatever the cell plotting mode selected (less confusing hopefully). 
- Cells checkbox also inactivate physiboss visualization