### PR TITLE
allow hill powers to be doubles in the table, too

### DIFF
--- a/bin/rules_tab.py
+++ b/bin/rules_tab.py
@@ -680,7 +680,7 @@ class Rules(QWidget):
 
             # ------- Hill power
             w_me = MyQLineEdit()
-            w_me.setValidator(QtGui.QIntValidator())
+            w_me.setValidator(QtGui.QDoubleValidator())
             w_me.setFrame(False)
             w_me.vname = w_me  
             w_me.wrow = irow


### PR DESCRIPTION
currently, the Hill power line edit allows a double and that can successfully be put into the table. You can then edit the double so long as you don't delete the `.`. Otherwise, you cannot re-insert the `.` to set a new float.