### PR TITLE
Fixed correct intracellular update when switching between panels

### DIFF
--- a/bin/cell_def_tab.py
+++ b/bin/cell_def_tab.py
@@ -3407,7 +3407,8 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
             # print("PhysiBoSS")
             logging.debug(f'intracellular is boolean')
             if self.param_d[self.current_cell_def]["intracellular"] is None:
-                self.param_d[self.current_cell_def]["intracellular"] = {"type": "maboss"}
+                self.param_d[self.current_cell_def]["intracellular"] = {}
+            self.param_d[self.current_cell_def]["intracellular"]["type"] = "maboss"
                 
             if 'initial_values' not in self.param_d[self.current_cell_def]["intracellular"].keys():
                 self.param_d[self.current_cell_def]["intracellular"]["initial_values"] = []
@@ -3455,13 +3456,14 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
             # logging.debug(f'intracellular is SBML ODEs')
             if "intracellular" not in self.param_d[self.current_cell_def].keys():
                 self.param_d[self.current_cell_def]["intracellular"] = {}
-                self.param_d[self.current_cell_def]["intracellular"]["type"] = "roadrunner"
+            self.param_d[self.current_cell_def]["intracellular"]["type"] = "roadrunner"
             self.ode_sbml_frame.show()
 
         elif index == 3:
             logging.debug(f'intracellular is dFBA')
             if self.param_d[self.current_cell_def]["intracellular"] is None:
-                self.param_d[self.current_cell_def]["intracellular"] = {"type": "dfba"}
+                self.param_d[self.current_cell_def]["intracellular"] = {}
+            self.param_d[self.current_cell_def]["intracellular"]["type"] = "dfba"
 
             if 'settings' not in self.param_d[self.current_cell_def]["intracellular"].keys():
                 self.param_d[self.current_cell_def]["intracellular"]["settings"] = {}

--- a/bin/cell_def_tab.py
+++ b/bin/cell_def_tab.py
@@ -6350,7 +6350,6 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
                         self.max_growth_rate.setText(growth_model["max_growth_rate"])
                     if "objective_reaction" in growth_model:
                         self.objective_reaction.setText(growth_model["objective_reaction"])
-                    print("IS THERE A BUG HERE?", self.param_d[cdname]["intracellular"])
 
                 # Populate Death Model Parameters
                 if "death_model" in self.param_d[cdname]["intracellular"]:


### PR DESCRIPTION
Follow-up PR related to Randy's comment:

"But upon doing further tests, I seem to experience unexpected behavior. If I create 2 cell types and select the dFBA panel for the 1st cell type, but then change it to the Boolean panel, then select the 2nd cell type (which has none for its Intracellular panel, then select the 1st cell type, it seems to have dFBA as its chosen panel, rather than Boolean."

After recreating, I have corrected for all the intracellular types (Boolean, Roadrunner, dFBA).

Cause: in intracellular_type_changed(), the "type" key in param_d was only written when the intracellular dict was None. If the cell type had previously been assigned a different intracellular model, the dict already existed and the "type" key was never updated. So basically update_intracellular_params() would read the "old" intracellular type and display the wrong panel when switching back to that cell type.

Now the "type" key is now  set to the correct value in each branch of intracellular_type_changed(), regardless of whether the intracellular dict was just created or already existed.

I have tested this by uploading a dfba model (ecoli acetic switch) and then adding a cell type , assigning a Boolean intracellular model, then switching to the first one, assign a Boolean model and then revert it to dFBA again. Everything seems to work, but please test this further.