### PR TITLE
remove old call from biwt

### DIFF
--- a/bin/biwt_tab.py
+++ b/bin/biwt_tab.py
@@ -1299,7 +1299,6 @@ class BioinformaticsWalkthroughWindow_WritePositions(BioinformaticsWalkthroughWi
             else:
                 print(f"BioinformaticsWalkthroughPlotWindow: {cell_type} not found in current list of cell types. Appending {cell_type}...")
                 # self.biwt.celldef_tab.new_cell_def_named(cell_type)
-                self.biwt.ics_tab.update_colors_list()
 
     def append_cell_definition_to_xml(self):
         xml_file_path = 'PhysiCell_new.xml'


### PR DESCRIPTION
this was a bug of my own making. this came from the biwt refactor that we merged back in January. v.2.44.0 had this function, v2.45.0 we had removed the function everywhere, and then the refactor reintroduced it only in `biwt_tab.py` (removed in this PR). so yeah, it's on me :)