### PR TITLE
fix: skip empty lines when reading rules from CSV

### DIFF
--- a/bin/rules_tab.py
+++ b/bin/rules_tab.py
@@ -1118,6 +1118,9 @@ class Rules(StudioTab):
                     irow = self.num_rules  # append
                     for elm in csv_reader:   # for each rule or comment
                         # raw = row.split('/')[0].strip()
+                        if len(elm) == 0:
+                            # print("--- skip empty line")
+                            continue
                         # print("  elm[0]= ",elm[0])
                         toggle_val = True
                         if elm[0][0] == '/':
@@ -1208,7 +1211,7 @@ class Rules(StudioTab):
             except Exception as e:
             # self.dialog_critical(str(e))
             # print("error opening config/cells_rules.csv")
-                print(f'fill_rules(): Error opening or reading {full_rules_fname}')
+                print(f'fill_rules(): Error opening or reading {full_rules_fname}: {str(e)}')
                 show_studio_warning_window(f'rules_tab.py: Error opening or reading {full_rules_fname}')
                 # logging.error(f'rules_tab.py: Error opening or reading {full_rules_fname}')
                 # sys.exit(1)


### PR DESCRIPTION
Since we are [no longer stripping comments from the rules file](https://github.com/PhysiCell-Tools/PhysiCell-Studio/blob/19597b715cded84ed0591f0b95bd6c653489802d/bin/rules_tab.py#L1115), blank lines in the rules file are parsed for rules, throwing an error when [checking if the first entry](https://github.com/PhysiCell-Tools/PhysiCell-Studio/blob/19597b715cded84ed0591f0b95bd6c653489802d/bin/rules_tab.py#L1123).

Thus, the following rules csv throws an error on parsing:
```csv
default,pressure,decreases,cycle entry,0,0.5,4,0

default,substrate,increases,apoptosis,1,1,1,0
```

Here's part of the console output on launching studio with these rules:
```sh
rule=  ['default', 'pressure', 'decreases', 'cycle entry', '0', '0.5', '4', '0']
rule=  ['default', 'substrate', 'increases', 'apoptosis', '1', '1', '1', '0']
fill_rules(): Error opening or reading /Users/dbergman1/PhysiCell_git/./config/cell_rules.csv
```
You can see it parses the file correctly on the smoke test for parsing the rules file, but then fails when actually filling in the GUI.