### PR TITLE
Add optional PhysiPKPD support behind a --pkpd flag

### DIFF
--- a/bin/cell_def_tab.py
+++ b/bin/cell_def_tab.py
@@ -319,11 +319,11 @@ class CellDef(StudioTab):
         self.tab_widget.addTab(self.create_interaction_tab(),"Interactions")
         if not self.xml_creator.nanohub_flag and not self.xml_creator.galaxy_flag:
             self.tab_widget.addTab(self.create_intracellular_tab(),"Intracellular")
+        else:
+            self.intracellular_type_dropdown = None
         if self.pkpd_flag:
             self.pd_setup_complete = False
             self.tab_widget.addTab(self.create_pd_tab(),"PD")
-        else:
-            self.intracellular_type_dropdown = None
         self.tab_widget.addTab(self.create_custom_data_tab(),"Custom Data")
         self.tab_widget.addTab(self.create_miscellaneous_tab(),"Misc")
 

--- a/bin/cell_def_tab.py
+++ b/bin/cell_def_tab.py
@@ -107,6 +107,10 @@ class CellDef(StudioTab):
         self.celldef_param_updates = CellDefParamUpdates(self)
 
         random.seed(42)   # for reproducibility (cough). Needed for pytest results.
+        self.pkpd_flag = xml_creator.pkpd_flag
+        self.force_precompute = True
+        self.pd_substrates = []
+
         self.param_d = {}  # a dict of dicts
         self.num_dec = 5  # how many digits to right of decimal point?
 
@@ -134,6 +138,7 @@ class CellDef(StudioTab):
                 }
                 """
 
+        self.config_tab = xml_creator.config_tab
         self.ics_tab = None
 
         self.current_cell_def = None
@@ -314,6 +319,9 @@ class CellDef(StudioTab):
         self.tab_widget.addTab(self.create_interaction_tab(),"Interactions")
         if not self.xml_creator.nanohub_flag and not self.xml_creator.galaxy_flag:
             self.tab_widget.addTab(self.create_intracellular_tab(),"Intracellular")
+        if self.pkpd_flag:
+            self.pd_setup_complete = False
+            self.tab_widget.addTab(self.create_pd_tab(),"PD")
         else:
             self.intracellular_type_dropdown = None
         self.tab_widget.addTab(self.create_custom_data_tab(),"Custom Data")
@@ -422,6 +430,9 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
         self.new_custom_data_params(cdname)
 
         self.new_miscellaneous_params(cdname)
+
+        if reset_mapping and self.pkpd_flag:
+            self.new_pd_data_params(cdname)
 
         # print("\n\n",self.param_d)
         # self.custom_data_tab.param_d = self.param_d
@@ -596,7 +607,7 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
         self.current_cell_def = cdname_copy
         # self.cell_type_name.setText(cdname)
 
-        self.add_new_celltype(cdname_copy)  # add to all qcomboboxes that have celltypes (e.g., in interactions)
+        self.add_new_celltype(cdname_copy, reset_mapping=False)  # add to all qcomboboxes that have celltypes (e.g., in interactions)
         # print('3) copy_cell_def(): param_d.keys=',self.param_d.keys())
 
         #-----  Update this new cell def's widgets' values
@@ -2280,6 +2291,120 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
         self.new_interaction_params(self.current_cell_def, True)
         self.tree_item_clicked_cb(self.tree.currentItem(), 0)
 
+    #--------------------------------------------------------
+    def pd_model_combobox_changed_cb(self, idx):
+        if self.current_cell_def is not None and self.current_pd_substrate is not None:
+            self.param_d[self.current_cell_def]["pd"][self.current_pd_substrate]["pd_model"] = self.pd_model_combobox.currentText()
+        if self.pd_setup_complete is False:
+            return
+        custom_data_key = f'{self.current_pd_substrate}_damage'
+        if self.pd_model_combobox.currentText() == "None":
+            self.disable_pd_parameters()
+            if custom_data_key in self.master_custom_var_d.keys():
+                delete_damage_var = True
+                for cd_name in self.celltypes_list:
+                    if ("pd_model" in self.param_d[cd_name]["pd"][self.current_pd_substrate].keys()) and (self.param_d[cd_name]["pd"][self.current_pd_substrate]["pd_model"] != "None"):
+                        delete_damage_var = False
+                        break
+                if delete_damage_var is True:
+                    self.delete_custom_data_row(custom_data_key)
+                    self.pd_substrates.remove(self.current_pd_substrate)
+        else:
+            self.enable_pd_parameters()
+            is_added = self.add_custom_data(custom_data_key,"0.0",False,"damage",f'Accumulated damage due to {self.current_pd_substrate}')
+            if is_added:
+                self.pd_substrates.append(self.current_pd_substrate)
+    #--------------------------------------------------------
+    def enable_pd_parameters(self):
+        self.pd_metabolism_rate.setEnabled(True)
+        self.pd_metabolism_rate.setStyleSheet("background-color: white; color: black")
+        metabolism_rate = "0"
+        if "metabolism_rate" in self.param_d[self.current_cell_def]["pd"][self.current_pd_substrate].keys():
+            metabolism_rate = str(self.param_d[self.current_cell_def]["pd"][self.current_pd_substrate]["metabolism_rate"])
+        self.param_d[self.current_cell_def]["pd"][self.current_pd_substrate]["metabolism_rate"] = metabolism_rate
+        self.pd_metabolism_rate.setText(metabolism_rate)
+
+        self.pd_constant_repair_rate.setEnabled(True)
+        self.pd_constant_repair_rate.setStyleSheet("background-color: white; color: black")
+        constant_repair_rate = "0"
+        if "constant_repair_rate" in self.param_d[self.current_cell_def]["pd"][self.current_pd_substrate].keys():
+            constant_repair_rate = str(self.param_d[self.current_cell_def]["pd"][self.current_pd_substrate]["constant_repair_rate"])
+        self.param_d[self.current_cell_def]["pd"][self.current_pd_substrate]["constant_repair_rate"] = constant_repair_rate
+        self.pd_constant_repair_rate.setText(constant_repair_rate)
+        
+        self.pd_linear_repair_rate.setEnabled(True)
+        self.pd_linear_repair_rate.setStyleSheet("background-color: white; color: black")
+        linear_repair_rate = "0"
+        if "linear_repair_rate" in self.param_d[self.current_cell_def]["pd"][self.current_pd_substrate].keys():
+            linear_repair_rate = str(self.param_d[self.current_cell_def]["pd"][self.current_pd_substrate]["linear_repair_rate"])
+        self.param_d[self.current_cell_def]["pd"][self.current_pd_substrate]["linear_repair_rate"] = linear_repair_rate
+        self.pd_linear_repair_rate.setText(linear_repair_rate)
+        
+        precompute = "true"
+        if self.force_precompute is False:
+            self.pd_precompute_checkbox.setEnabled(True)
+            self.pd_precompute_checkbox.setStyleSheet("background-color: white; color: black")
+            if "precompute" in self.param_d[self.current_cell_def]["pd"][self.current_pd_substrate].keys():
+                precompute = str(self.param_d[self.current_cell_def]["pd"][self.current_pd_substrate]["precompute"])
+            self.param_d[self.current_cell_def]["pd"][self.current_pd_substrate]["precompute"] = precompute
+            if precompute == "true" or self.force_precompute is True:
+                self.pd_precompute_checkbox.setChecked(True)
+            else:
+                self.pd_precompute_checkbox.setChecked(False)
+        else:
+            self.param_d[self.current_cell_def]["pd"][self.current_pd_substrate]["precompute"] = precompute
+
+        self.pd_dt.setEnabled(True)
+        self.pd_dt.setStyleSheet("background-color: white; color: black")
+        dt = str(self.config_tab.diffusion_dt.text())
+        if "dt" in self.param_d[self.current_cell_def]["pd"][self.current_pd_substrate].keys():
+            dt = str(self.param_d[self.current_cell_def]["pd"][self.current_pd_substrate]["dt"])
+        self.param_d[self.current_cell_def]["pd"][self.current_pd_substrate]["dt"] = dt
+        self.pd_dt.setText(dt)
+
+    def disable_pd_parameters(self):
+        self.pd_metabolism_rate.setEnabled(False)
+        self.pd_metabolism_rate.setStyleSheet("background-color: lightgray; color: black")
+        self.pd_constant_repair_rate.setEnabled(False)
+        self.pd_constant_repair_rate.setStyleSheet("background-color: lightgray; color: black")
+        self.pd_linear_repair_rate.setEnabled(False)
+        self.pd_linear_repair_rate.setStyleSheet("background-color: lightgray; color: black")
+        self.pd_precompute_checkbox.setEnabled(False)
+        self.pd_precompute_checkbox.setStyleSheet("background-color: lightgray; color: black")
+        self.pd_dt.setEnabled(False)
+        self.pd_dt.setStyleSheet("background-color: lightgray; color: black")
+    #--------------------------------------------------------
+    def pd_metabolism_rate_changed_cb(self, text):
+        self.param_d[self.current_cell_def]["pd"][self.current_pd_substrate]["metabolism_rate"] = text
+    #--------------------------------------------------------
+    def pd_constant_repair_rate_changed_cb(self, text):
+        self.param_d[self.current_cell_def]["pd"][self.current_pd_substrate]["constant_repair_rate"] = text
+    #--------------------------------------------------------
+    def pd_linear_repair_rate_changed_cb(self, text):
+        self.param_d[self.current_cell_def]["pd"][self.current_pd_substrate]["linear_repair_rate"] = text
+    #--------------------------------------------------------
+    def pd_precompute_checkbox_clicked(self, bval):
+        self.param_d[self.current_cell_def]["pd"][self.current_pd_substrate]["precompute"] = "true" if bval else "false"
+    #--------------------------------------------------------
+    def pd_dt_changed_cb(self, text):
+        self.param_d[self.current_cell_def]["pd"][self.current_pd_substrate]["dt"] = text
+    #--------------------------------------------------------
+    def pd_dt_edit_finished_cb(self):
+        text = self.pd_dt.text()
+        if self.pd_precompute_checkbox.isChecked() is False:
+            self.param_d[self.current_cell_def]["pd"][self.current_pd_substrate]["dt"] = text
+            return
+        dt = float(text)
+        diffusion_dt = float(self.config_tab.diffusion_dt.text())
+        # check if the time step is obviously not a multiple of diffusion_dt
+        if abs(dt / diffusion_dt - round(dt/diffusion_dt)) > 0.0001:
+            dt = (dt // diffusion_dt)
+            dt *= diffusion_dt
+            if dt < diffusion_dt: # the flooring could result in dt = 0, which is not what we're here for
+                dt = diffusion_dt
+            text = str(dt)
+            self.pd_dt.setText(text)
+        self.param_d[self.current_cell_def]["pd"][self.current_pd_substrate]["dt"] = text
     #--------------------------------------------------------
     def cell_adhesion_affinity_changed(self,text):
         # print("cell_adhesion_affinity_changed:  text=",text)
@@ -4055,6 +4180,137 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
         intracellular_tab.setLayout(glayout)
         return intracellular_tab_scroll
 
+    def create_pd_tab(self):
+        self.pd_tab = QWidget()
+        lineedit_stylesheet = """ 
+            background-color: rgb(236,236,236);
+            QLineEdit {
+                color: #000000;
+                background-color: #FFFFFF; 
+            }
+            """
+        self.pd_tab.setStyleSheet("background-color: rgb(236,236,236)")
+
+        self.pd_tab_layout = QVBoxLayout()
+        # vlayout = QVBoxLayout()
+
+        self.pd_substrate_combobox = QComboBox_custom()
+        self.pd_substrate_combobox.currentIndexChanged.connect(self.pd_substrate_changed_cb)  # beware: will be triggered on a ".clear" too
+        self.pd_tab_layout.addWidget(self.pd_substrate_combobox) # w, row, column, rowspan, colspan
+
+        hbox = QHBoxLayout()
+        label = QLabel("model")
+        # label.setFixedWidth(self.label_width)
+        label.setAlignment(QtCore.Qt.AlignRight)
+        # label.setStyleSheet("border: 1px solid black;")
+        # idr += 1
+        hbox.addWidget(label) # w, row, column, rowspan, colspan
+
+        self.pd_model_combobox = QComboBox_custom()
+        self.pd_model_combobox.currentIndexChanged.connect(self.pd_model_combobox_changed_cb)
+        self.pd_model_combobox.addItem("None")
+        self.pd_model_combobox.addItem("AUC")
+        self.pd_model_combobox.addItem("AUC_amount")
+        hbox.addWidget(self.pd_model_combobox) # w, row, column, rowspan, colspan
+
+        label = QLabel("Metabolism Rate")
+        label.setAlignment(QtCore.Qt.AlignRight)
+        hbox.addWidget(label) # w, row, column, rowspan, colspan
+
+        self.pd_metabolism_rate = QLineEdit()
+        self.pd_metabolism_rate.setFixedWidth(60)
+        self.pd_metabolism_rate.setEnabled(False)
+        self.pd_metabolism_rate.setValidator(QtGui.QDoubleValidator())
+        self.pd_metabolism_rate.textChanged.connect(self.pd_metabolism_rate_changed_cb)
+        hbox.addWidget(self.pd_metabolism_rate)
+
+        units = QLabel("1/min")
+        units.setAlignment(QtCore.Qt.AlignLeft)
+        hbox.addWidget(units) # w, row, column, rowspan, colspan
+
+        label = QLabel("Linear Repair Rate")
+        label.setAlignment(QtCore.Qt.AlignRight)
+        hbox.addWidget(label) # w, row, column, rowspan, colspan
+
+        self.pd_linear_repair_rate = QLineEdit()
+        self.pd_linear_repair_rate.setFixedWidth(60)
+        self.pd_linear_repair_rate.setEnabled(False)
+        self.pd_linear_repair_rate.setValidator(QtGui.QDoubleValidator())
+        self.pd_linear_repair_rate.textChanged.connect(self.pd_linear_repair_rate_changed_cb)
+        hbox.addWidget(self.pd_linear_repair_rate)
+
+        units = QLabel("1/min")
+        units.setAlignment(QtCore.Qt.AlignLeft)
+        hbox.addWidget(units) # w, row, column, rowspan, colspan
+
+        label = QLabel("Constant Repair Rate")
+        label.setAlignment(QtCore.Qt.AlignRight)
+        hbox.addWidget(label) # w, row, column, rowspan, colspan
+
+        self.pd_constant_repair_rate = QLineEdit()
+        self.pd_constant_repair_rate.setFixedWidth(60)
+        self.pd_constant_repair_rate.setEnabled(False)
+        self.pd_constant_repair_rate.setValidator(QtGui.QDoubleValidator())
+        self.pd_constant_repair_rate.textChanged.connect(self.pd_constant_repair_rate_changed_cb)
+        hbox.addWidget(self.pd_constant_repair_rate)
+
+        units = QLabel("damage/min")
+        units.setAlignment(QtCore.Qt.AlignLeft)
+        hbox.addWidget(units) # w, row, column, rowspan, colspan
+
+        hbox.addStretch()
+        self.pd_tab_layout.addLayout(hbox)
+
+        hbox = QHBoxLayout()
+
+        self.pd_precompute_checkbox = QCheckBox("Precompute Terms")
+        # self.pd_precompute_checkbox.setFixedWidth(130)
+        self.pd_precompute_checkbox.setEnabled(False)
+        self.pd_precompute_checkbox.setChecked(True)
+        self.pd_precompute_checkbox.setStyleSheet("background-color: lightgray")
+        self.pd_precompute_checkbox.clicked.connect(self.pd_precompute_checkbox_clicked)
+        hbox.addWidget(self.pd_precompute_checkbox) # w, row, column, rowspan, colspan
+
+        hbox.insertSpacing(2, 50)
+
+        label = QLabel("PD dt")
+        label.setAlignment(QtCore.Qt.AlignRight)
+        hbox.addWidget(label)
+
+        self.pd_dt = QLineEdit()
+        self.pd_dt.setFixedWidth(100)
+        self.pd_dt.setEnabled(False)
+        self.pd_dt.setValidator(QtGui.QDoubleValidator())
+        self.pd_dt.textChanged.connect(self.pd_dt_changed_cb)
+        self.pd_dt.editingFinished.connect(self.pd_dt_edit_finished_cb)
+        hbox.addWidget(self.pd_dt)
+
+        self.config_tab.diffusion_dt.editingFinished.connect(self.pd_dt_edit_finished_cb)
+
+
+        units = QLabel("min")
+        units.setAlignment(QtCore.Qt.AlignLeft)
+        hbox.addWidget(units)
+
+        hbox.addStretch()
+        self.pd_tab_layout.addLayout(hbox)
+
+        #------
+        # vlayout.setVerticalSpacing(10)  # rwh - argh
+        self.pd_tab_layout.addStretch()
+        self.pd_tab.setLayout(self.pd_tab_layout)
+
+        self.pd_tab.scroll_area = QScrollArea()
+
+        self.pd_tab.scroll_area.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOn)
+        self.pd_tab.scroll_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOn)
+        self.pd_tab.scroll_area.setWidgetResizable(True)
+        self.pd_tab.scroll_area.setWidget(self.pd_tab)
+
+        self.pd_setup_complete = True
+
+        return self.pd_tab.scroll_area
+
     # --- mechanics
     def enable_mech_params(self, bval):
         print("---- enable_mech_params()  bval= ",bval)
@@ -4213,6 +4469,33 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
 
 
     #--------------------------------------------------------
+    def delete_custom_data_row(self, key):
+        if key not in self.master_custom_var_d.keys():
+            print(f' {key} was not found in the custom data table.')
+            return
+        row = self.master_custom_var_d[key][0]
+        self.delete_key_from_master_custom_var_d(key, row=row)
+        for irow in range(row, self.max_custom_data_rows):
+            self.custom_data_table.cellWidget(irow,self.custom_icol_name).wrow -= 1  # sufficient to only decr the "name" column
+        self.custom_data_table.removeRow(row)
+        self.add_row_custom_table(self.max_custom_data_rows - 1)
+        self.enable_all_custom_data()
+        
+    #--------------------------------------------------------
+    def delete_key_from_master_custom_var_d(self, key, row = None, debug_me = False):
+        if row is None:
+            row = self.master_custom_var_d[key][0]
+        self.master_custom_var_d.pop(key)
+        for k in self.master_custom_var_d.keys():
+            if self.master_custom_var_d[k][0] > row:   # remember: [row, units, description]
+                self.master_custom_var_d[k][0] -= 1
+        # remove (pop) this custom var name from ALL cell types
+        for cdef in self.param_d.keys():
+            if debug_me:
+                print(f"   popping {key} from {cdef}")
+            self.param_d[cdef]['custom_data'].pop(key)
+
+    #--------------------------------------------------------
     # Delete an entire row from the Custom Data subtab. Somewhat tricky...
     def delete_custom_data_cb(self):
         debug_me = False
@@ -4227,16 +4510,15 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
             print(" master_custom_var_d.keys()= ",self.master_custom_var_d.keys())
             # print(" master_custom_var_d= ",self.master_custom_var_d)
 
+        if self.pkpd_flag:
+            # check it is not a damage variable
+            for substrate in self.pd_substrates:
+                if varname == substrate + "_damage":
+                    self.custom_table_error(row,1,f"(PKPD) You are deleting a PD substrate! Set to \"None\" all PD models for {substrate} instead.")
+                    return
+
         if varname in self.master_custom_var_d.keys():
-            self.master_custom_var_d.pop(varname)
-            for key in self.master_custom_var_d.keys():
-                if self.master_custom_var_d[key][0] > row:   # remember: [row, units, description]
-                    self.master_custom_var_d[key][0] -= 1
-            # remove (pop) this custom var name from ALL cell types
-            for cdef in self.param_d.keys():
-                if debug_me:
-                    print(f"   popping {varname} from {cdef}")
-                self.param_d[cdef]['custom_data'].pop(varname)
+            self.delete_key_from_master_custom_var_d(varname, row=row, debug_me=debug_me)
 
         # Since each widget in each row had an associated row #, we need to decrement all those following
         # the row that was just deleted.
@@ -5383,6 +5665,14 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
         # self.uptake_rate.setText(secretion_substrate_path.find(".//uptake_rate").text)
         # self.secretion_net_export_rate.setText(secretion_substrate_path.find(".//net_export_rate").text)
 
+    def pd_substrate_changed_cb(self, idx):
+        # print('------ secretion_substrate_changed_cb(): idx = ',idx)
+        self.current_pd_substrate = self.pd_substrate_combobox.currentText()
+        # print("    self.current_pd_substrate = ",self.current_pd_substrate)
+        if idx == -1:
+            return
+
+        self.update_pd_params()
 
     #-------------------------------------------------------------------------------------
         # self.cycle_dropdown.addItem("live cells")   # 0 -> 0
@@ -5435,6 +5725,22 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
         # print("cell_def_tab.py: ------- fill_substrates_comboboxes:  self.substrate_list = ",self.substrate_list)
         self.physiboss_update_list_signals()
         self.physiboss_update_list_behaviours()
+        self.pkpd_fill_substrates_comboboxes()
+
+    def pkpd_fill_substrates_comboboxes(self):
+        if self.pkpd_flag is False:
+            return
+        self.pd_substrate_combobox.clear()
+        uep = self.xml_root.find('.//microenvironment_setup')  # find unique entry point
+        if uep:
+            idx = 0
+            for var in uep.findall('variable'):
+                # vp.append(var)
+                logging.debug(f' --> {var.attrib["name"]}')
+                name = var.attrib['name']
+                self.pd_substrate_combobox.addItem(name)
+        
+
 
     #-----------------------------------------------------------------------------------------
     # Fill them using the given model (the .xml)
@@ -5513,6 +5819,8 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
         self.motility_substrate_dropdown.removeItem(item_idx)
         self.motility2_substrate_dropdown.removeItem(item_idx)
         self.secretion_substrate_dropdown.removeItem(item_idx)
+        if self.pkpd_flag:
+            self.pd_substrate_combobox.removeItem(item_idx)
         # self.motility_substrate_dropdown.clear()
         # self.secretion_substrate_dropdown.clear()
 
@@ -5557,6 +5865,12 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
         self.physiboss_update_list_signals()
         self.physiboss_update_list_behaviours()
 
+        self.pkpd_add_new_substrate_comboboxes(substrate_name)
+
+    def pkpd_add_new_substrate_comboboxes(self, substrate_name):
+        if self.pkpd_flag is False:
+            return
+        self.pd_substrate_combobox.addItem(substrate_name)
     #-----------------------------------------------------------------------------------------
     # When a user renames a substrate in the Microenv tab, we need to update all 
     # cell_defs data structures that reference it.
@@ -5578,6 +5892,8 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
                 self.motility2_substrate_dropdown.setItemText(idx, new_name)
             if old_name == self.secretion_substrate_dropdown.itemText(idx):
                 self.secretion_substrate_dropdown.setItemText(idx, new_name)
+            if self.pkpd_flag and old_name == self.pd_substrate_combobox.itemText(idx):
+                self.pd_substrate_combobox.setItemText(idx, new_name)
 
         # 2) update in the param_d dict
         for cdname in self.param_d.keys():  # for all cell defs, rename motility/chemotaxis and secretion substrate
@@ -5594,8 +5910,14 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
             self.param_d[cdname]["secretion"][new_name] = self.param_d[cdname]["secretion"].pop(old_name)
             self.param_d[cdname]["chemotactic_sensitivity"][new_name] = self.param_d[cdname]["chemotactic_sensitivity"].pop(old_name)
 
+            if self.pkpd_flag:
+                self.param_d[cdname]["pd"][new_name] = self.param_d[cdname]["pd"].pop(old_name)
+
         if old_name == self.current_secretion_substrate:
             self.current_secretion_substrate = new_name
+
+        if self.pkpd_flag and old_name == self.current_pd_substrate:
+            self.current_pd_substrate = new_name
 
         if self.rules_tab:
             # print("     calling self.rules_tab.substrate_rename")
@@ -5938,7 +6260,7 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
         self.param_d[cdname]["intracellular"] = None
 
 
-    def add_new_substrate(self, sub_name):  # called for both "New" and "Copy" of substrate/signal
+    def add_new_substrate(self, sub_name, sub_to_copy):  # called for both "New" and "Copy" of substrate/signal
         self.add_new_substrate_comboboxes(sub_name)
 
         sval = self.default_sval
@@ -5964,8 +6286,15 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
         if self.rules_tab:
             self.rules_tab.add_new_substrate(sub_name)
 
+        if self.pkpd_flag:
+            self.pkpd_add_new_substrate(sub_name, sub_to_copy)
 
-    def add_new_celltype(self, cdname):
+    def pkpd_add_new_substrate(self, sub_name, sub_to_copy):
+        for cdname in self.param_d.keys():
+            D = {} if sub_to_copy is None else self.param_d[cdname]["pd"][sub_to_copy]
+            self.param_d[cdname]["pd"][sub_name] = D
+
+    def add_new_celltype(self, cdname, reset_mapping=True):
         self.add_new_celltype_comboboxes(cdname)
         self.physiboss_update_list_signals()
         self.physiboss_update_list_behaviours()
@@ -5978,7 +6307,8 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
         #     self.param_d[cdname]["secretion"][sub_name]["secretion_target"] = sval
         #     self.param_d[cdname]["secretion"][sub_name]["uptake_rate"] = sval
         #     self.param_d[cdname]["secretion"][sub_name]["net_export_rate"] = sval
-
+        if reset_mapping is True and self.pkpd_flag is True:
+            self.pd_model_combobox.setCurrentIndex(self.pd_model_combobox.findText("None"))
 
     def new_custom_data_params(self, cdname):
         logging.debug(f'------- new_custom_data_params() -----')
@@ -5995,6 +6325,13 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
             self.param_d[cdname]['custom_data'][key] = [self.custom_var_value_str_default, self.custom_var_conserved_default]   # [value, conserved flag]
             idx += 1
 
+    #-----------------------------------------------------------------------------------------
+    def new_pd_data_params(self, cdname):
+        if "pd" not in self.param_d[cdname].keys():
+            return
+        for substrate in self.param_d[cdname]["pd"].keys():
+            self.param_d[cdname]["pd"][substrate] = {} # set to empty dictionary, enable_pd_parameters() will take care of the rest
+            
     def new_miscellaneous_params(self, cdname):
         self.param_d[cdname]["par_dists"] = {}
         self.param_d[cdname]["par_dists_disabled"] = True
@@ -6201,6 +6538,46 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
             returnValue = msgBox.exec()
 
         # rwh: also update the qdropdown to select the substrate
+
+    def update_pd_params(self):
+        cdname = self.current_cell_def
+        if cdname == None:
+            return
+        logging.debug(f'update_pd_params(): cdname = {cdname}')
+        logging.debug(f'update_pd_params(): self.current_pd_substrate = {self.current_pd_substrate}')
+        logging.debug(f'{self.param_d[cdname]["pd"]}')
+        if "pd_model" in self.param_d[cdname]["pd"][self.current_pd_substrate].keys():
+            self.pd_model_combobox.setCurrentIndex(self.pd_model_combobox.findText(self.param_d[cdname]["pd"][self.current_pd_substrate]["pd_model"]))
+        else:
+            self.pd_model_combobox.setCurrentIndex(self.pd_model_combobox.findText("None"))
+
+        if "metabolism_rate" in self.param_d[cdname]["pd"][self.current_pd_substrate].keys():
+            self.pd_metabolism_rate.setText(str(self.param_d[cdname]["pd"][self.current_pd_substrate]["metabolism_rate"]))
+        else:
+            self.pd_metabolism_rate.setText("0")
+
+        if "constant_repair_rate" in self.param_d[cdname]["pd"][self.current_pd_substrate].keys():
+            self.pd_constant_repair_rate.setText(str(self.param_d[cdname]["pd"][self.current_pd_substrate]["constant_repair_rate"]))
+        else:
+            self.pd_constant_repair_rate.setText("0")
+
+        if "linear_repair_rate" in self.param_d[cdname]["pd"][self.current_pd_substrate].keys():
+            self.pd_linear_repair_rate.setText(str(self.param_d[cdname]["pd"][self.current_pd_substrate]["linear_repair_rate"]))
+        else:
+            self.pd_linear_repair_rate.setText("0")
+
+        if self.force_precompute is True:
+                self.pd_precompute_checkbox.setChecked(True)
+        else:
+            if "precompute" in self.param_d[cdname]["pd"][self.current_pd_substrate].keys():
+                self.pd_precompute_checkbox.setChecked(str(self.param_d[cdname]["pd"][self.current_pd_substrate]["precompute"])=="true")
+            else:
+                self.pd_precompute_checkbox.setChecked(True)
+
+        if "dt" in self.param_d[cdname]["pd"][self.current_pd_substrate].keys():
+            self.pd_dt.setText(str(self.param_d[cdname]["pd"][self.current_pd_substrate]["dt"]))
+        else:
+            self.pd_dt.setText(str(self.config_tab.diffusion_dt.text()))
 
     #-----------------------------------------------------------------------------------------
     def update_interaction_params(self):
@@ -6478,7 +6855,6 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
                 #------------- conserved
                 self.custom_data_table.cellWidget(irow,self.custom_icol_conserved).setChecked(self.param_d[cdname]['custom_data'][key][1]) 
 
-
                 # NOTE: the following two (units, desc) are the same across all cell types
                 #------------- units
                 # print(f"    update_custom_data_params(): master_custom_var_d= {self.master_custom_var_d}")
@@ -6507,6 +6883,37 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
             for pdple in self.par_dist_par_lineedit:
                 pdple.setText('') # do not let the previous cell def param values affect this cell def param values
 
+    def add_custom_data(self, key, value, conserved_flag, units, desc):
+        if key in self.master_custom_var_d.keys():
+            return False
+        if self.rules_tab:
+            self.rules_tab.update_rules_for_custom_data = True
+        irow = len(self.master_custom_var_d.keys()) -  ("" in self.master_custom_var_d.keys()) # plan to put it here
+        for i in range(self.max_custom_data_rows): # but if a smaller index is found, put it there
+            if self.custom_data_table.cellWidget(i,self.custom_icol_name).text() == "":
+                irow = i
+                break
+        self.custom_data_edit_active = False
+
+        self.master_custom_var_d[key] = [irow, units, desc] # dict: [unique custom var name]=[row#, units, desc]
+
+        self.custom_data_table.cellWidget(irow,self.custom_icol_name).setText(key)   # rwh: tricky; custom var name
+        self.custom_data_table.cellWidget(irow,self.custom_icol_name).prev = None
+
+        self.custom_data_table.cellWidget(irow,self.custom_icol_value).setText(value) # [value, conserved flag]
+        self.custom_data_table.cellWidget(irow,self.custom_icol_conserved).setChecked(conserved_flag)
+        for cd_name in self.celltypes_list:
+            self.param_d[cd_name]['custom_data'][key] = [value, conserved_flag]
+
+
+        self.custom_data_table.cellWidget(irow,self.custom_icol_units).setText(units)
+        self.master_custom_var_d[key][1] = units
+
+        self.custom_data_table.cellWidget(irow,self.custom_icol_desc).setText(desc)
+        self.master_custom_var_d[key][2] = desc
+
+        self.custom_data_edit_active = True
+        return True
     #-----------------------------------------------------------------------------------------
     def reset_to_blank(self):
         self.clear_custom_data_tab()
@@ -6549,9 +6956,10 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
         self.update_intracellular_params()
         # self.update_molecular_params()
         self.update_custom_data_params()
+        if self.pkpd_flag:
+            self.update_pd_params()
 
         self.update_misc_params()
-
 
     #-------------------------------------------------------------------
     def first_cell_def_name(self):
@@ -6984,6 +7392,44 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
                 msgBox.setText(msg)
                 msgBox.setStandardButtons(QMessageBox.Ok)
                 returnValue = msgBox.exec()
+
+    def fill_xml_pd(self, cell_def):
+        if self.pkpd_flag is False:
+            return
+        cname = cell_def.attrib["name"]
+        elm_created = False
+        for substrate in self.param_d[cname]["pd"].keys():
+            if "pd_model" not in self.param_d[cname]["pd"][substrate].keys() or self.param_d[cname]["pd"][substrate]["pd_model"] == "None":
+                continue # ignore empty pd
+            if elm_created is False:
+                pd_elm = ET.SubElement(cell_def, "PD")
+                pd_elm.text = self.indent10  # affects indent of child
+                pd_elm.tail = "\n" + self.indent10
+                elm_created = True
+            elm = ET.SubElement(pd_elm, "substrate",{"name":substrate})
+            subelm = ET.SubElement(elm, "model")
+            subelm.text = self.param_d[cname]["pd"][substrate]["pd_model"]
+            subelm.tail = "\n" + self.indent12
+
+            subelm = ET.SubElement(elm, "metabolism_rate")
+            subelm.text = self.param_d[cname]["pd"][substrate]["metabolism_rate"]
+            subelm.tail = "\n" + self.indent12
+            
+            subelm = ET.SubElement(elm, "constant_repair_rate")
+            subelm.text = self.param_d[cname]["pd"][substrate]["constant_repair_rate"]
+            subelm.tail = "\n" + self.indent12
+            
+            subelm = ET.SubElement(elm, "linear_repair_rate")
+            subelm.text = self.param_d[cname]["pd"][substrate]["linear_repair_rate"]
+            subelm.tail = "\n" + self.indent12
+            
+            subelm = ET.SubElement(elm, "precompute")
+            subelm.text = self.param_d[cname]["pd"][substrate]["precompute"]
+            subelm.tail = "\n" + self.indent12
+            
+            subelm = ET.SubElement(elm, "dt")
+            subelm.text = self.param_d[cname]["pd"][substrate]["dt"]
+            subelm.tail = "\n" + self.indent12
 
     #-------------------------------------------------------------------
     # Read values from the GUI widgets and generate/write a new XML
@@ -7610,6 +8056,8 @@ Please fix the IDs in the Cell Types tab. Also, be mindful of how this may affec
                     self.fill_xml_secretion(pheno,cdef)
                     self.fill_xml_interactions(pheno,cdef)
                     self.fill_xml_intracellular(pheno,cdef)
+
+                    self.fill_xml_pd(elm)
 
                     # ------- custom data ------- 
                     custom_data = ET.SubElement(elm, 'custom_data')

--- a/bin/microenv_tab.py
+++ b/bin/microenv_tab.py
@@ -6,17 +6,20 @@ Dr. Paul Macklin (macklinp@iu.edu)
 """
 
 import sys
+import os
 import copy
 import logging
 import xml.etree.ElementTree as ET  # https://docs.python.org/2/library/xml.etree.elementtree.html
 # from ElementTree_pretty import prettify
 
+from studio_classes import QLineEdit_custom, FolderPathValidator, FileNameValidator, QLabelSeparator
+
 from PyQt5 import QtCore, QtGui
-# from PyQt5.QtWidgets import *
-from PyQt5.QtWidgets import QFrame,QWidget,QLineEdit,QHBoxLayout,QVBoxLayout,QPushButton,QLabel,QScrollArea,QTreeWidget,QTreeWidgetItem,QSplitter,QMessageBox
+# # from PyQt5.QtWidgets import *
+from PyQt5.QtWidgets import QFrame,QWidget,QLineEdit,QHBoxLayout,QVBoxLayout,QPushButton,QLabel,QScrollArea,QTreeWidget,QTreeWidgetItem,QSplitter,QMessageBox,QTabWidget
 
 from PyQt5.QtGui import QIcon, QDoubleValidator
-from studio_classes import QCheckBox_custom
+from studio_classes import QCheckBox_custom, QComboBox_custom
 
 class QHLine(QFrame):
     def __init__(self):
@@ -25,15 +28,13 @@ class QHLine(QFrame):
         self.setFrameShadow(QFrame.Sunken)
 
 class SubstrateDef(QWidget):
-    def __init__(self, config_tab):
+    def __init__(self, config_tab, pkpd_flag):
         super().__init__()
-        # global self.microenv_params
-
+        self.pk_setup_complete = False
         self.param_d = {}  # a dict of dicts - rwh/todo, used anymore?
         # self.substrate = {}
         self.current_substrate = None
         self.xml_root = None
-        self.config_tab = config_tab
         self.new_substrate_count = 1
 
         self.is_3D = False
@@ -43,20 +44,21 @@ class SubstrateDef(QWidget):
 
         self.ics_tab = None   # update in studio.py
         self.rules_tab = None   # update in studio.py
-
-        # self.stacked_w = QStackedWidget()
-        # self.stack_w = []
-        # self.stack_w.append(QStackedWidget())
-        # self.stacked_w.addWidget(self.stack_w[0])
-
-        #---------------
-        # self.cell_defs = CellDefInstances()
-        # self.microenv_hbox = QHBoxLayout()
-
-        splitter = QSplitter()
-        leftwidth = 150
-        # splitter.setSizes([split_leftwidth, self.width() - leftwidth])
-        # splitter.setSizes([leftwidth, self.width() - leftwidth])
+        # global self.microenv_params
+        self.config_tab = config_tab
+        self.pkpd_flag = pkpd_flag
+        self.tab_widget = QTabWidget()
+        self.splitter = QSplitter()
+        self.scroll_substrate_tree = QScrollArea()
+        self.splitter.addWidget(self.scroll_substrate_tree)
+        self.splitter.addWidget(self.tab_widget)
+        self.tab_widget.addTab(self.create_base_microenv_tab(),"Base")
+        if self.pkpd_flag:
+            self.tab_widget.addTab(self.create_pk_tab(),"PK")
+            self.pk_setup_complete = True
+            
+        self.layout = QVBoxLayout(self)
+        self.layout.addWidget(self.splitter)
 
         tree_widget_width = 240
         tree_widget_height = 400
@@ -105,7 +107,7 @@ class SubstrateDef(QWidget):
         # self.microenv_hbox.addWidget(self.name_list)
 
 
-        self.scroll_substrate_tree = QScrollArea()
+        # self.scroll_substrate_tree = QScrollArea()
         # self.scroll_substrate_tree.setFixedWidth(tree_widget_width)
 
         # self.tree_w = QWidget()
@@ -146,10 +148,342 @@ class SubstrateDef(QWidget):
         tree_w_vbox.addLayout(tree_w_hbox)
         self.tree_w.setLayout(tree_w_vbox)
         self.scroll_substrate_tree.setWidget(self.tree_w)
+
+        # self.layout.addLayout(controls_hbox)
+ 
+        # self.layout.addWidget(self.tabs)
+        # self.layout.addWidget(QHLine())
+        # self.layout.addWidget(self.params)
+
+        # self.layout.addWidget(self.scroll_area)
+        # self.layout.addWidget(splitter)
+
+        self.new_substrate_count = self.config_tab.count_substrates()
+
+    def create_pk_tab(self):
+        self.pk_tab = QWidget()
+        self.pk_tab_layout = QVBoxLayout()
+
+        label_width = 150
+        units_width = 150
+
+        hbox = QHBoxLayout()
+        hbox.addStretch()
+        label = QLabel("PK Model")
+        label.setAlignment(QtCore.Qt.AlignRight)
+        hbox.addWidget(label)
+
+        self.pk_model_combobox = QComboBox_custom()
+        self.pk_model_combobox.currentIndexChanged.connect(self.pk_model_combobox_changed_cb)
+        self.pk_model_combobox.addItem("None")
+        self.pk_model_combobox.addItem("Constant")
+        self.pk_model_combobox.addItem("1C")
+        self.pk_model_combobox.addItem("2C")
+        self.pk_model_combobox.addItem("SBML")
+        hbox.addWidget(self.pk_model_combobox)
+
+        label = QLabel("Schedule Format")
+        label.setAlignment(QtCore.Qt.AlignRight)
+        hbox.addWidget(label)
+
+        self.pk_schedule_format_combobox = QComboBox_custom() # put this here before connecting pk_model_combobox to cb to prevent error
+        self.pk_schedule_format_combobox.setEnabled(False)
+        self.pk_schedule_format_combobox.addItem("parameters")
+        self.pk_schedule_format_combobox.addItem("csv")
+        self.pk_schedule_format_combobox.currentIndexChanged.connect(self.pk_schedule_format_combobox_changed_cb)
+        hbox.addWidget(self.pk_schedule_format_combobox)
+
+        label = QLabel("Biot number")
+        label.setAlignment(QtCore.Qt.AlignRight)
+        hbox.addWidget(label)
+
+        self.pk_biot_number = QLineEdit_custom()
+        self.pk_biot_number.setFixedWidth(60)
+        self.pk_biot_number.setEnabled(False)
+        self.pk_biot_number.setValidator(QtGui.QDoubleValidator())
+        self.pk_biot_number.textChanged.connect(self.pk_biot_number_changed_cb)
+        hbox.addWidget(self.pk_biot_number)
+
+        hbox.addStretch()
+        self.pk_tab_layout.addLayout(hbox)
+
+        self.pk_tab_layout.addWidget(QLabelSeparator("Schedule parameters"))
+        
+        hbox = QHBoxLayout()
+
+        label = QLabel("Number of doses:")
+        label.setAlignment(QtCore.Qt.AlignLeft)
+        label.setStyleSheet("font-weight: bold")
+        hbox.addWidget(label)
+
+        label = QLabel("Total #")
+        label.setAlignment(QtCore.Qt.AlignRight)
+        hbox.addWidget(label)
+
+        self.pk_total_doses = QLineEdit_custom()
+        self.pk_total_doses.setFixedWidth(30)
+        self.pk_total_doses.setEnabled(False)
+        self.pk_total_doses.setValidator(QtGui.QIntValidator())
+        self.pk_total_doses.textChanged.connect(self.pk_total_doses_changed_cb)
+        hbox.addWidget(self.pk_total_doses)
+
+        label = QLabel("Loading #")
+        label.setAlignment(QtCore.Qt.AlignRight)
+        hbox.addWidget(label)
+
+        self.pk_loading_doses = QLineEdit_custom()
+        self.pk_loading_doses.setFixedWidth(30)
+        self.pk_loading_doses.setEnabled(False)
+        self.pk_loading_doses.setValidator(QtGui.QIntValidator())
+        self.pk_loading_doses.textChanged.connect(self.pk_loading_doses_changed_cb)
+        hbox.addWidget(self.pk_loading_doses)
+
+        hbox.addStretch()
+        self.pk_tab_layout.addLayout(hbox)
+
+        hbox = QHBoxLayout()
+
+        label = QLabel("Dose amount:")
+        label.setAlignment(QtCore.Qt.AlignLeft)
+        label.setStyleSheet("font-weight: bold")
+        hbox.addWidget(label)
+
+        label = QLabel("Regular Dose")
+        label.setAlignment(QtCore.Qt.AlignRight)
+        hbox.addWidget(label)
+
+        self.pk_regular_dose = QLineEdit_custom()
+        self.pk_regular_dose.setFixedWidth(60)
+        self.pk_regular_dose.setEnabled(False)
+        self.pk_regular_dose.setValidator(QtGui.QDoubleValidator())
+        self.pk_regular_dose.textChanged.connect(self.pk_regular_dose_changed_cb)
+        hbox.addWidget(self.pk_regular_dose)
+
+        label = QLabel("Loading Dose")
+        label.setAlignment(QtCore.Qt.AlignRight)
+        hbox.addWidget(label)
+
+        self.pk_loading_dose = QLineEdit_custom()
+        self.pk_loading_dose.setFixedWidth(60)
+        self.pk_loading_dose.setEnabled(False)
+        self.pk_loading_dose.setValidator(QtGui.QDoubleValidator())
+        self.pk_loading_dose.textChanged.connect(self.pk_loading_dose_changed_cb)
+        hbox.addWidget(self.pk_loading_dose)
+
+        hbox.addStretch()
+        self.pk_tab_layout.addLayout(hbox)
+
+        hbox = QHBoxLayout()
+
+        label = QLabel("Dose timing:")
+        label.setAlignment(QtCore.Qt.AlignLeft)
+        label.setStyleSheet("font-weight: bold")
+        hbox.addWidget(label)
+
+        label = QLabel("First Dose Time")
+        label.setAlignment(QtCore.Qt.AlignRight)
+        hbox.addWidget(label)
+
+        self.pk_first_dose_time = QLineEdit_custom()
+        self.pk_first_dose_time.setFixedWidth(30)
+        self.pk_first_dose_time.setEnabled(False)
+        self.pk_first_dose_time.setValidator(QtGui.QDoubleValidator())
+        self.pk_first_dose_time.textChanged.connect(self.pk_first_dose_time_changed_cb)
+        hbox.addWidget(self.pk_first_dose_time)
+
+        units = QLabel("days")
+        label.setAlignment(QtCore.Qt.AlignLeft)
+        hbox.addWidget(units)
+
+        label = QLabel("Dose Interval")
+        label.setAlignment(QtCore.Qt.AlignRight)
+        hbox.addWidget(label)
+
+        self.pk_dose_interval = QLineEdit_custom()
+        self.pk_dose_interval.setFixedWidth(30)
+        self.pk_dose_interval.setEnabled(False)
+        self.pk_dose_interval.setValidator(QtGui.QDoubleValidator())
+        self.pk_dose_interval.textChanged.connect(self.pk_dose_interval_changed_cb)
+        hbox.addWidget(self.pk_dose_interval)
+
+        units = QLabel("days")
+        label.setAlignment(QtCore.Qt.AlignLeft)
+        hbox.addWidget(units)
+
+        hbox.addStretch()
+
+        self.pk_tab_layout.addLayout(hbox)
+
+        self.pk_tab_layout.addWidget(QLabelSeparator("PK rate parameters"))
+
+        # PK rate parameters
+        hbox = QHBoxLayout()
+
+        label = QLabel("Elimination Rate")
+        label.setAlignment(QtCore.Qt.AlignRight)
+        hbox.addWidget(label)
+
+        self.pk_elimination_rate = QLineEdit_custom()
+        self.pk_elimination_rate.setFixedWidth(60)
+        self.pk_elimination_rate.setEnabled(False)
+        self.pk_elimination_rate.setValidator(QtGui.QDoubleValidator())
+        self.pk_elimination_rate.textChanged.connect(self.pk_elimination_rate_changed_cb)
+        hbox.addWidget(self.pk_elimination_rate)
+
+        units = QLabel("1/min")
+        label.setAlignment(QtCore.Qt.AlignLeft)
+        hbox.addWidget(units)
+
+        label = QLabel("k12")
+        label.setAlignment(QtCore.Qt.AlignRight)
+        hbox.addWidget(label)
+
+        self.pk_k12 = QLineEdit_custom()
+        self.pk_k12.setFixedWidth(60)
+        self.pk_k12.setEnabled(False)
+        self.pk_k12.setValidator(QtGui.QDoubleValidator())
+        self.pk_k12.textChanged.connect(self.pk_k12_changed_cb)
+        hbox.addWidget(self.pk_k12)
+
+        units = QLabel("1/min")
+        label.setAlignment(QtCore.Qt.AlignLeft)
+        hbox.addWidget(units)
+
+        label = QLabel("k21")
+        label.setAlignment(QtCore.Qt.AlignRight)
+        hbox.addWidget(label)
+
+        self.pk_k21 = QLineEdit_custom()
+        self.pk_k21.setFixedWidth(60)
+        self.pk_k21.setEnabled(False)
+        self.pk_k21.setValidator(QtGui.QDoubleValidator())
+        self.pk_k21.textChanged.connect(self.pk_k21_changed_cb)
+        hbox.addWidget(self.pk_k21)
+
+        units = QLabel("1/min")
+        label.setAlignment(QtCore.Qt.AlignLeft)
+        hbox.addWidget(units)
+
+        label = QLabel("R (V_C/V_P)")
+        label.setAlignment(QtCore.Qt.AlignRight)
+        hbox.addWidget(label)
+
+        self.pk_volume_ratio = QLineEdit_custom()
+        self.pk_volume_ratio.setFixedWidth(60)
+        self.pk_volume_ratio.setEnabled(False)
+        self.pk_volume_ratio.setValidator(QtGui.QDoubleValidator())
+        self.pk_volume_ratio.textChanged.connect(self.pk_volume_ratio_changed_cb)
+        hbox.addWidget(self.pk_volume_ratio)
+
+        hbox.addStretch()
+        self.pk_tab_layout.addLayout(hbox)
+
+        self.pk_tab_layout.addWidget(QLabelSeparator("Supporting files"))
+
+        hbox = QHBoxLayout()
+        label = QLabel("CSV-defined PK schedule")
+        label.setAlignment(QtCore.Qt.AlignLeft)
+        label.setStyleSheet("font-weight: bold")
+        hbox.addWidget(label)
+        hbox.addStretch()
+
+        self.pk_tab_layout.addLayout(hbox)
+
+        hbox = QHBoxLayout()
+
+        label = QLabel("Folder")
+        label.setAlignment(QtCore.Qt.AlignRight)
+        hbox.addWidget(label)
+
+        self.pk_csv_folder = QLineEdit_custom()
+        self.pk_csv_folder.setEnabled(False)
+        self.pk_csv_folder.setValidator(FolderPathValidator())
+        self.pk_csv_folder.textChanged.connect(self.pk_csv_folder_changed_cb)
+        hbox.addWidget(self.pk_csv_folder)
+
+        label = QLabel("Filename")
+        label.setAlignment(QtCore.Qt.AlignRight)
+        hbox.addWidget(label)
+
+        self.pk_csv_filename = QLineEdit_custom()
+        self.pk_csv_filename.setEnabled(False)
+        self.pk_csv_filename.setValidator(FileNameValidator(self.pk_csv_folder))
+        self.pk_csv_filename.textChanged.connect(self.pk_csv_filename_changed_cb)
+        hbox.addWidget(self.pk_csv_filename)
+
+        self.pk_tab_layout.addLayout(hbox)
+
+        hbox = QHBoxLayout()
+        label = QLabel("SBML file")
+        label.setAlignment(QtCore.Qt.AlignLeft)
+        label.setStyleSheet("font-weight: bold")
+        hbox.addWidget(label)
+        hbox.addStretch()
+
+        self.pk_tab_layout.addLayout(hbox)
+
+        hbox = QHBoxLayout()
+
+        label = QLabel("Folder")
+        label.setAlignment(QtCore.Qt.AlignRight)
+        hbox.addWidget(label)
+
+        self.pk_sbml_folder = QLineEdit_custom()
+        self.pk_sbml_folder.setEnabled(False)
+        self.pk_sbml_folder.setValidator(FolderPathValidator())
+        self.pk_sbml_folder.textChanged.connect(self.pk_sbml_folder_changed_cb)
+        hbox.addWidget(self.pk_sbml_folder)
+        
+        label = QLabel("Filename")
+        label.setAlignment(QtCore.Qt.AlignRight)
+        hbox.addWidget(label)
+        self.pk_sbml_filename = QLineEdit_custom()
+        self.pk_sbml_filename.setEnabled(False)
+        self.pk_sbml_filename.setValidator(FileNameValidator(self.pk_sbml_folder))
+        self.pk_sbml_filename.textChanged.connect(self.pk_sbml_filename_changed_cb)
+        hbox.addWidget(self.pk_sbml_filename)
+
+        hbox.addStretch()
+        self.pk_tab_layout.addLayout(hbox)
+
+        hbox = QHBoxLayout()
+        label = QLabel(f"The boxes above turn red if the file cannot be found.\nRelative paths are relative to {os.getcwd()} ")
+        hbox.addWidget(label)
+        hbox.addStretch()
+        self.pk_tab_layout.addLayout(hbox)
+
+        self.pk_tab_layout.addStretch()
+        self.pk_tab.setLayout(self.pk_tab_layout)
+
+        self.pk_tab.scroll_area = QScrollArea()
+
+        self.pk_tab.scroll_area.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOn)
+        self.pk_tab.scroll_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOn)
+        self.pk_tab.scroll_area.setWidgetResizable(True)
+        self.pk_tab.scroll_area.setWidget(self.pk_tab)
+
+        return self.pk_tab.scroll_area
+
+    def create_base_microenv_tab(self):
+        # self.stacked_w = QStackedWidget()
+        # self.stack_w = []
+        # self.stack_w.append(QStackedWidget())
+        # self.stacked_w.addWidget(self.stack_w[0])
+
+        #---------------
+        # self.cell_defs = CellDefInstances()
+        # self.microenv_hbox = QHBoxLayout()
+
+        # splitter = QSplitter()
+        leftwidth = 150
+        # splitter.setSizes([split_leftwidth, self.width() - leftwidth])
+        # splitter.setSizes([leftwidth, self.width() - leftwidth])
+
+        
         # self.scroll_substrate_tree.setWidget(self.tree)
         #---------
         # splitter.addWidget(self.tree)
-        splitter.addWidget(self.scroll_substrate_tree)
+        # splitter.addWidget(self.scroll_substrate_tree)
 
         #-------------------------------------------
         # self.tab = QWidget()
@@ -160,11 +494,11 @@ class SubstrateDef(QWidget):
         units_width = 150
 
         # self.scroll = QScrollArea()
-        self.scroll_area = QScrollArea()
-        splitter.addWidget(self.scroll_area)
+        # self.scroll_area = QScrollArea()
+        # splitter.addWidget(self.scroll_area)
         # self.microenv_hbox.addWidget(self.scroll_area)
 
-        self.microenv_params = QWidget()
+        self.microenv_params_tab = QWidget()
         stylesheet = """ 
             QPushButton {
                 color: #000000;
@@ -368,17 +702,17 @@ class SubstrateDef(QWidget):
         #==================================================================
         self.vbox.addStretch()
 
-        self.microenv_params.setLayout(self.vbox)
+        self.microenv_params_tab.setLayout(self.vbox)
 
-        self.scroll_area.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOn)
-        self.scroll_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOn)
-        self.scroll_area.setWidgetResizable(True)
-        self.scroll_area.setWidget(self.microenv_params)
+        self.microenv_params_tab.scroll_area = QScrollArea()
+        # self.microenv_params_tab.addWidget(self.microenv_params_tab.scroll_area)
 
-        self.layout = QVBoxLayout(self)
-        self.layout.addWidget(splitter)
+        self.microenv_params_tab.scroll_area.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOn)
+        self.microenv_params_tab.scroll_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOn)
+        self.microenv_params_tab.scroll_area.setWidgetResizable(True)
+        self.microenv_params_tab.scroll_area.setWidget(self.microenv_params_tab)
 
-        self.new_substrate_count = self.config_tab.count_substrates()
+        return self.microenv_params_tab.scroll_area
 
     def apply_dc_cb(self):
         text = self.dirichlet_bc.text()
@@ -388,7 +722,6 @@ class SubstrateDef(QWidget):
         self.dirichlet_ymax.setText(text)
         self.dirichlet_zmin.setText(text)
         self.dirichlet_zmax.setText(text)
-
 
     def update_3D(self):
         try:
@@ -409,8 +742,170 @@ class SubstrateDef(QWidget):
     def diffusion_coef_changed(self, text):
         self.param_d[self.current_substrate]["diffusion_coef"] = text
 
+    def enable_schedule_parameters(self):
+        self.pk_csv_folder.setEnabled(False)
+        self.pk_csv_filename.setEnabled(False)
+
+        self.pk_total_doses.setEnabled(True)
+        self.pk_total_doses.setText(str(self.param_d[self.current_substrate]["total_doses"]))
+        
+        self.pk_loading_doses.setEnabled(True)
+        self.pk_loading_doses.setText(str(self.param_d[self.current_substrate]["loading_doses"]))
+
+        self.pk_first_dose_time.setEnabled(True)
+        self.pk_first_dose_time.setText(str(self.param_d[self.current_substrate]["first_dose_time"]))
+
+        self.pk_dose_interval.setEnabled(True)
+        self.pk_dose_interval.setText(str(self.param_d[self.current_substrate]["dose_interval"]))
+
+        self.pk_regular_dose.setEnabled(True)
+        self.pk_regular_dose.setText(str(self.param_d[self.current_substrate]["regular_dose"]))
+
+        self.pk_loading_dose.setEnabled(True)
+        self.pk_loading_dose.setText(str(self.param_d[self.current_substrate]["loading_dose"]))
+
+    def disable_all_schedule(self):
+        self.pk_schedule_format_combobox.setEnabled(False)
+        self.disable_schedule_parameters()
+
+    def pk_model_combobox_changed_cb(self, idx):
+        if self.current_substrate is not None:
+            self.param_d[self.current_substrate]["pk_model"] = self.pk_model_combobox.currentText()
+        if self.pk_setup_complete is False:
+            return
+        if self.pk_model_combobox.currentText() == "None" or self.pk_model_combobox.currentText() == "SBML":
+            self.disable_all_schedule()
+            self.disable_rate_parameters()
+            self.pk_csv_folder.setEnabled(False)
+            self.pk_csv_filename.setEnabled(False)
+        elif self.pk_model_combobox.currentText() == "Constant":
+            self.pk_schedule_format_combobox.setCurrentIndex(self.pk_schedule_format_combobox.findText("csv"))
+            self.pk_schedule_format_combobox.setEnabled(False)
+            self.disable_rate_parameters()
+            self.pk_csv_folder.setEnabled(True)
+            self.pk_csv_filename.setEnabled(True)
+        else:
+            self.enable_all_schedule()
+            self.enable_rate_parameters()
+
+        if self.pk_model_combobox.currentText() == "None":
+            self.pk_biot_number.setEnabled(False)
+        else:
+            self.pk_biot_number.setEnabled(True)
+            self.pk_biot_number.setText(str(self.param_d[self.current_substrate]["biot_number"]))
+
+        if self.pk_model_combobox.currentText() == "SBML":
+            self.pk_sbml_folder.setEnabled(True)
+            self.pk_sbml_folder.setText(str(self.param_d[self.current_substrate]["sbml_folder"]))
+            self.pk_sbml_filename.setEnabled(True)
+            self.pk_sbml_filename.setText(str(self.param_d[self.current_substrate]["sbml_filename"]))
+        else:
+            self.pk_sbml_folder.setEnabled(False)
+            self.pk_sbml_folder.setText(str(self.param_d[self.current_substrate]["sbml_folder"]))
+            self.pk_sbml_filename.setEnabled(False)
+            self.pk_sbml_filename.setText(str(self.param_d[self.current_substrate]["sbml_filename"]))
+
+    def enable_rate_parameters(self):
+        self.disable_rate_parameters() # simple way to turn off any unneeded parameters
+
+        self.pk_elimination_rate.setEnabled(True)
+        self.pk_elimination_rate.setText(str(self.param_d[self.current_substrate]["elimination_rate"]))
+        
+        if self.pk_model_combobox.currentText() == "2C":
+            self.pk_k12.setEnabled(True)
+            self.pk_k12.setText(str(self.param_d[self.current_substrate]["k12"]))
+
+            self.pk_k21.setEnabled(True)
+            self.pk_k21.setText(str(self.param_d[self.current_substrate]["k21"]))
+
+            self.pk_volume_ratio.setEnabled(True)
+            self.pk_volume_ratio.setText(str(self.param_d[self.current_substrate]["volume_ratio"]))
+
+    def enable_all_schedule(self):
+        self.pk_schedule_format_combobox.setEnabled(True)
+        if self.pk_schedule_format_combobox.currentText() == "parameters":
+            self.enable_schedule_parameters()
+        else:
+            self.disable_schedule_parameters()
+            self.pk_csv_folder.setEnabled(True)
+            self.pk_csv_filename.setEnabled(True)
+
+    def disable_rate_parameters(self):
+        self.pk_elimination_rate.setEnabled(False)
+        self.pk_k12.setEnabled(False)
+        self.pk_k21.setEnabled(False)
+        self.pk_volume_ratio.setEnabled(False)
+
+    def disable_schedule_parameters(self):
+        self.pk_total_doses.setEnabled(False)
+        self.pk_loading_doses.setEnabled(False)
+        self.pk_first_dose_time.setEnabled(False)
+        self.pk_dose_interval.setEnabled(False)
+        self.pk_regular_dose.setEnabled(False)
+        self.pk_loading_dose.setEnabled(False)
+
+    def pk_schedule_format_combobox_changed_cb(self, idx):
+        if self.current_substrate is not None:
+            self.param_d[self.current_substrate]["schedule_format"] = self.pk_schedule_format_combobox.currentText()
+
+        if self.pk_model_combobox.currentText() == "None" or self.pk_model_combobox.currentText() == "SBML" or self.pk_schedule_format_combobox.currentText() != "parameters":
+            self.disable_schedule_parameters()
+            if self.pk_schedule_format_combobox.currentText() == "csv":
+                self.pk_csv_folder.setEnabled(True)
+                self.pk_csv_filename.setEnabled(True)
+        else:
+            self.enable_schedule_parameters()
+
+    def pk_total_doses_changed_cb(self, text):
+        self.param_d[self.current_substrate]["total_doses"] = text
+
+    def pk_loading_doses_changed_cb(self, text):
+        self.param_d[self.current_substrate]["loading_doses"] = text
+
+    def pk_first_dose_time_changed_cb(self, text):
+        self.param_d[self.current_substrate]["first_dose_time"] = text
+
+    def pk_dose_interval_changed_cb(self, text):
+        self.param_d[self.current_substrate]["dose_interval"] = text
+
+    def pk_regular_dose_changed_cb(self, text):
+        self.param_d[self.current_substrate]["regular_dose"] = text
+
+    def pk_loading_dose_changed_cb(self, text):
+        self.param_d[self.current_substrate]["loading_dose"] = text
+
+    def pk_elimination_rate_changed_cb(self, text):
+        self.param_d[self.current_substrate]["elimination_rate"] = text
+
+    def pk_k12_changed_cb(self, text):
+        self.param_d[self.current_substrate]["k12"] = text
+
+    def pk_k21_changed_cb(self, text):
+        self.param_d[self.current_substrate]["k21"] = text
+
+    def pk_volume_ratio_changed_cb(self, text):
+        self.param_d[self.current_substrate]["volume_ratio"] = text
+
+    def pk_biot_number_changed_cb(self, text):
+        self.param_d[self.current_substrate]["biot_number"] = text
+
+    def pk_csv_folder_changed_cb(self, text):
+        self.param_d[self.current_substrate]["pk_csv_folder"] = text
+        self.pk_csv_filename.check_validity(self.pk_csv_filename.text())
+
+    def pk_csv_filename_changed_cb(self, text):
+        self.param_d[self.current_substrate]["pk_csv_filename"] = text
+
+    def pk_sbml_folder_changed_cb(self, text):
+        self.param_d[self.current_substrate]["sbml_folder"] = text
+        self.pk_sbml_filename.check_validity(self.pk_sbml_filename.text())
+
+    def pk_sbml_filename_changed_cb(self, text):
+        self.param_d[self.current_substrate]["sbml_filename"] = text
+
     def decay_rate_changed(self, text):
         self.param_d[self.current_substrate]["decay_rate"] = text
+
     def init_cond_changed(self, text):
         self.param_d[self.current_substrate]["init_cond"] = text
 
@@ -495,6 +990,25 @@ class SubstrateDef(QWidget):
         self.param_d[subname]["enable_zmin"] = bval
         self.param_d[subname]["enable_zmax"] = bval
 
+        if self.pkpd_flag:
+            self.param_d[subname]["pk_model"] = "None"
+            self.param_d[subname]["schedule_format"] = "parameters"
+            self.param_d[subname]["total_doses"] = "0"
+            self.param_d[subname]["loading_doses"] = "0"
+            self.param_d[subname]["first_dose_time"] = "0"
+            self.param_d[subname]["dose_interval"] = "1"
+            self.param_d[subname]["regular_dose"] = "0"
+            self.param_d[subname]["loading_dose"] = "0"
+            self.param_d[subname]["elimination_rate"] = "0"
+            self.param_d[subname]["k12"] = "0"
+            self.param_d[subname]["k21"] = "0"
+            self.param_d[subname]["volume_ratio"] = "1"
+            self.param_d[subname]["biot_number"] = "1"
+            self.param_d[subname]["pk_csv_folder"] = None
+            self.param_d[subname]["pk_csv_filename"] = None
+            self.param_d[subname]["sbml_folder"] = "./config"
+            self.param_d[subname]["sbml_filename"] = "PK_default.xml"
+
         # NOooo!
         # self.param_d["gradients"] = bval
         # self.param_d["track_in_agents"] = bval
@@ -505,7 +1019,8 @@ class SubstrateDef(QWidget):
 
         self.new_substrate_count += 1
 
-        self.celldef_tab.add_new_substrate(subname)
+        substrate_to_copy = None
+        self.celldef_tab.add_new_substrate(subname, substrate_to_copy)
         self.config_tab.add_new_substrate(subname)
         self.ics_tab.add_new_substrate(subname)
         # self.celldef_tab.add_new_substrate_comboboxes(subname)
@@ -554,7 +1069,8 @@ class SubstrateDef(QWidget):
 
         # self.celldef_tab.add_new_substrate_comboboxes(subname)
 
-        self.celldef_tab.add_new_substrate(subname)
+        substrate_to_copy = self.current_substrate
+        self.celldef_tab.add_new_substrate(subname, substrate_to_copy)
         self.config_tab.add_new_substrate(subname)
         self.ics_tab.add_new_substrate(subname)
 
@@ -717,6 +1233,24 @@ class SubstrateDef(QWidget):
             self.enable_zmin.setChecked(self.param_d[self.current_substrate]["enable_zmin"])
             self.enable_zmax.setChecked(self.param_d[self.current_substrate]["enable_zmax"])
 
+        if self.pkpd_flag:
+            self.pk_model_combobox.setCurrentIndex(self.pk_model_combobox.findText(self.param_d[self.current_substrate]["pk_model"]))
+            self.pk_schedule_format_combobox.setCurrentIndex(self.pk_schedule_format_combobox.findText(self.param_d[self.current_substrate]["schedule_format"]))
+            self.pk_total_doses.setText(str(self.param_d[self.current_substrate]["total_doses"]))
+            self.pk_loading_doses.setText(str(self.param_d[self.current_substrate]["loading_doses"]))
+            self.pk_first_dose_time.setText(str(self.param_d[self.current_substrate]["first_dose_time"]))
+            self.pk_dose_interval.setText(str(self.param_d[self.current_substrate]["dose_interval"]))
+            self.pk_regular_dose.setText(str(self.param_d[self.current_substrate]["regular_dose"]))
+            self.pk_loading_dose.setText(str(self.param_d[self.current_substrate]["loading_dose"]))
+            self.pk_elimination_rate.setText(str(self.param_d[self.current_substrate]["elimination_rate"]))
+            self.pk_k12.setText(str(self.param_d[self.current_substrate]["k12"]))
+            self.pk_k21.setText(str(self.param_d[self.current_substrate]["k21"]))
+            self.pk_volume_ratio.setText(str(self.param_d[self.current_substrate]["volume_ratio"]))
+            self.pk_biot_number.setText(str(self.param_d[self.current_substrate]["biot_number"]))
+            self.pk_csv_folder.setText(str(self.param_d[self.current_substrate]["pk_csv_folder"]))
+            self.pk_csv_filename.setText(str(self.param_d[self.current_substrate]["pk_csv_filename"]))
+            self.pk_sbml_folder.setText(str(self.param_d[self.current_substrate]["sbml_folder"]))
+            self.pk_sbml_filename.setText(str(self.param_d[self.current_substrate]["sbml_filename"]))
 
         # global to all substrates
         self.gradients.setChecked(self.param_d["gradients"])
@@ -841,6 +1375,120 @@ class SubstrateDef(QWidget):
                         self.param_d[substrate_name]["enable_zmin"] = default_dc_enabled
                         self.param_d[substrate_name]["enable_zmax"] = default_dc_enabled
 
+                    if self.pkpd_flag:
+                        pk_path = var_path.find(".//PK")
+                        if pk_path is None:
+                            pk_model_enabled = "false"
+                        else:
+                            pk_model_enabled = pk_path.attrib["enabled"]
+                        schedule_format = "parameters"
+                        total_doses = "0"
+                        loading_doses = "0"
+                        first_dose_time = "0"
+                        dose_interval = "1"
+                        regular_dose = "0"
+                        loading_dose = "0"
+                        elimination_rate = "0"
+                        k12 = "0"
+                        k21 = "0"
+                        volume_ratio = "1"
+                        biot_number = "1"
+                        csv_folder = None
+                        csv_filename = None
+                        sbml_folder = "./config"
+                        sbml_filename = "PK_default.xml"
+                        if pk_model_enabled == "true":
+                            pk_model = pk_path.find(".//model").text
+                            if pk_model != "SBML":
+                                schedule_elm = pk_path.find(".//schedule")
+                                if schedule_elm is not None:
+                                    schedule_format = schedule_elm.attrib["format"]
+                                    if schedule_format == "parameters":
+                                        total_doses_elm = schedule_elm.find(".//total_doses")
+                                        if total_doses_elm is not None and total_doses_elm.text is not None:
+                                            total_doses = total_doses_elm.text
+                                        loading_doses_elm = schedule_elm.find(".//loading_doses")
+                                        if loading_doses_elm is not None and loading_doses_elm.text is not None:
+                                            loading_doses = loading_doses_elm.text
+                                        first_dose_time_elm = schedule_elm.find(".//first_dose_time")
+                                        if first_dose_time_elm is not None and first_dose_time_elm.text is not None:
+                                            first_dose_time = first_dose_time_elm.text
+                                        dose_interval_elm = schedule_elm.find(".//dose_interval")
+                                        if dose_interval_elm is not None and dose_interval_elm.text is not None:
+                                            dose_interval = dose_interval_elm.text
+                                        regular_dose_elm = schedule_elm.find(".//regular_dose")
+                                        if regular_dose_elm is not None and regular_dose_elm.text is not None:
+                                            regular_dose = regular_dose_elm.text
+                                        loading_dose_elm = schedule_elm.find(".//loading_dose")
+                                        if loading_dose_elm is not None and loading_dose_elm.text is not None:
+                                            loading_dose = loading_dose_elm.text
+                                    elif schedule_format == "csv":
+                                        csv_folder_elm = pk_path.find(".//folder")
+                                        if csv_folder_elm is not None and csv_folder_elm.text is not None:
+                                            csv_folder = csv_folder_elm.text
+                                        csv_filename_elm = pk_path.find(".//filename")
+                                        if csv_filename_elm is not None and csv_filename_elm.text is not None:
+                                            csv_filename = csv_filename_elm.text
+                                elimination_rate_elm = pk_path.find(".//elimination_rate")
+                                if elimination_rate_elm is not None and elimination_rate_elm.text is not None:
+                                    elimination_rate = elimination_rate_elm.text
+                                k12_elm = pk_path.find(".//k12")
+                                if k12_elm is not None and k12_elm.text is not None:
+                                    k12 = k12_elm.text
+                                k21_elm = pk_path.find(".//k21")
+                                if k21_elm is not None and k21_elm.text is not None:
+                                    k21 = k21_elm.text
+                                volume_ratio_elm = pk_path.find(".//volume_ratio")
+                                if volume_ratio_elm is not None and volume_ratio_elm.text is not None:
+                                    volume_ratio = volume_ratio_elm.text
+                            else:
+                                sbml_folder_elm = pk_path.find(".//sbml_folder")
+                                if sbml_folder_elm is not None and sbml_folder_elm.text is not None:
+                                    sbml_folder = sbml_folder_elm.text
+                                sbml_filename_elm = pk_path.find(".//sbml_filename")
+                                if sbml_filename_elm is not None and sbml_filename_elm.text is not None:
+                                    sbml_filename = sbml_filename_elm.text
+                            biot_number_elm = pk_path.find(".//biot_number")
+                            if biot_number_elm is not None and biot_number_elm.text is not None:
+                                biot_number = biot_number_elm.text
+                                    
+                        else:
+                            pk_model = "None"
+
+                        self.param_d[substrate_name]["pk_model"] = pk_model
+                        self.param_d[substrate_name]["schedule_format"] = schedule_format
+                        self.param_d[substrate_name]["total_doses"] = total_doses
+                        self.param_d[substrate_name]["loading_doses"] = loading_doses
+                        self.param_d[substrate_name]["first_dose_time"] = first_dose_time
+                        self.param_d[substrate_name]["dose_interval"] = dose_interval
+                        self.param_d[substrate_name]["regular_dose"] = regular_dose
+                        self.param_d[substrate_name]["loading_dose"] = loading_dose
+                        self.param_d[substrate_name]["elimination_rate"] = elimination_rate
+                        self.param_d[substrate_name]["k12"] = k12
+                        self.param_d[substrate_name]["k21"] = k21
+                        self.param_d[substrate_name]["volume_ratio"] = volume_ratio
+                        self.param_d[substrate_name]["biot_number"] = biot_number
+                        self.param_d[substrate_name]["pk_csv_folder"] = csv_folder
+                        self.param_d[substrate_name]["pk_csv_filename"] = csv_filename
+                        self.param_d[substrate_name]["sbml_folder"] = sbml_folder
+                        self.param_d[substrate_name]["sbml_filename"] = sbml_filename
+
+                        if idx == 1:
+                            self.pk_model_combobox.setCurrentIndex(self.pk_model_combobox.findText(pk_model))
+                            self.pk_schedule_format_combobox.setCurrentIndex(self.pk_schedule_format_combobox.findText(schedule_format))
+                            self.pk_total_doses.setText(str(total_doses))
+                            self.pk_loading_doses.setText(str(loading_doses))
+                            self.pk_first_dose_time.setText(str(first_dose_time))
+                            self.pk_dose_interval.setText(str(dose_interval))
+                            self.pk_regular_dose.setText(str(regular_dose))
+                            self.pk_loading_dose.setText(str(loading_dose))
+                            self.pk_elimination_rate.setText(str(elimination_rate))
+                            self.pk_k12.setText(str(k12))
+                            self.pk_k21.setText(str(k21))
+                            self.pk_volume_ratio.setText(str(volume_ratio))
+                            self.pk_biot_number.setText(str(biot_number))
+                            self.pk_sbml_filename.setText(str(sbml_filename))
+
                 elif var.tag == 'options':
                     self.param_d["gradients"] = False
                     self.param_d["track_in_agents"] = False
@@ -898,6 +1546,7 @@ class SubstrateDef(QWidget):
         indent6 = '\n      '
         indent8 = '\n        '
         indent10 = '\n          '
+        indent12 = '\n             '
 
         idx = 0
         for substrate in self.param_d.keys():
@@ -984,6 +1633,73 @@ class SubstrateDef(QWidget):
                     "enabled":str(self.param_d[substrate]["enable_zmax"])} )
                 subelm2.text = self.param_d[substrate]["dirichlet_zmax"]
                 subelm2.tail = indent8
+
+                if self.pkpd_flag:
+                    if self.param_d[substrate]["pk_model"] == "None":
+                        subelm = ET.SubElement(elm, "PK",{"enabled":"false"})
+                    else:
+                        subelm = ET.SubElement(elm, "PK",{"enabled":"true"})
+                        subelm.text = indent10
+                        subelm.tail = indent8
+                        
+                        subelm2 = ET.SubElement(subelm, "model")
+                        subelm2.text = self.param_d[substrate]["pk_model"]
+                        subelm2.tail = indent10
+
+                        if self.param_d[substrate]["pk_model"] != "SBML":
+                            subelm2 = ET.SubElement(subelm, "schedule",{"format":self.param_d[substrate]["schedule_format"]})
+                            if self.param_d[substrate]["schedule_format"] == "parameters":
+                                subelm3 = ET.SubElement(subelm2, "total_doses")
+                                subelm3.text = self.param_d[substrate]["total_doses"]
+                                subelm3.tail = indent12
+                                subelm3 = ET.SubElement(subelm2, "loading_doses")
+                                subelm3.text = self.param_d[substrate]["loading_doses"]
+                                subelm3.tail = indent12
+                                subelm3 = ET.SubElement(subelm2, "first_dose_time",{"units":"days"})
+                                subelm3.text = self.param_d[substrate]["first_dose_time"]
+                                subelm3.tail = indent12
+                                subelm3 = ET.SubElement(subelm2, "dose_interval",{"units":"days"})
+                                subelm3.text = str(self.param_d[substrate]["dose_interval"]) # no idea why this one needs to be explicitly converted to a string and not the others...
+                                subelm3.tail = indent12
+                                subelm3 = ET.SubElement(subelm2, "regular_dose")
+                                subelm3.text = str(self.param_d[substrate]["regular_dose"]) # no idea why this one needs to be explicitly converted to a string and not the others...
+                                subelm3.tail = indent12
+                                subelm3 = ET.SubElement(subelm2, "loading_dose")
+                                subelm3.text = str(self.param_d[substrate]["loading_dose"]) # no idea why this one needs to be explicitly converted to a string and not the others...
+                                subelm3.tail = indent12
+
+                            elif self.param_d[substrate]["schedule_format"] == "csv":
+                                subelm3 = ET.SubElement(subelm2, "folder")
+                                subelm3.text = self.param_d[substrate]["pk_csv_folder"]
+                                subelm3.tail = indent12
+                                subelm3 = ET.SubElement(subelm2, "filename")
+                                subelm3.text = self.param_d[substrate]["pk_csv_filename"]
+                                subelm3.tail = indent12
+
+                            if self.param_d[substrate]["pk_model"] in ["1C", "2C"]:
+                                subelm2 = ET.SubElement(subelm, "elimination_rate",{"units":"1/min"})
+                                subelm2.text = self.param_d[substrate]["elimination_rate"]
+                                subelm2.tail = indent10
+                                if self.param_d[substrate]["pk_model"] == "2C":
+                                    subelm2 = ET.SubElement(subelm, "k12",{"units":"1/min"})
+                                    subelm2.text = self.param_d[substrate]["k12"]
+                                    subelm2.tail = indent10
+                                    subelm2 = ET.SubElement(subelm, "k21",{"units":"1/min"})
+                                    subelm2.text = self.param_d[substrate]["k21"]
+                                    subelm2.tail = indent10
+                                    subelm2 = ET.SubElement(subelm, "volume_ratio")
+                                    subelm2.text = self.param_d[substrate]["volume_ratio"]
+                                    subelm2.tail = indent10
+                        else:
+                            subelm2 = ET.SubElement(subelm, "sbml_folder")
+                            subelm2.text = str(self.param_d[substrate]["sbml_folder"])
+                            subelm2.tail = indent10
+                            subelm2 = ET.SubElement(subelm, "sbml_filename")
+                            subelm2.text = str(self.param_d[substrate]["sbml_filename"])
+                            subelm2.tail = indent10
+                        subelm2 = ET.SubElement(subelm, "biot_number")
+                        subelm2.text = str(self.param_d[substrate]["biot_number"])
+                        subelm2.tail = indent10
                         
                 uep.insert(idx,elm)
                 idx += 1

--- a/bin/populate_tree_cell_defs.py
+++ b/bin/populate_tree_cell_defs.py
@@ -67,7 +67,78 @@ def handle_parse_error(section_str):
     # returnValue = msgBox.exec()
     sys.exit(-1)
 
-def populate_tree_cell_defs(cell_def_tab, skip_validate):
+def pkpd_populate_tree_cell_defs(cell_def_tab, uep, pkpd_flag):
+    if pkpd_flag is False:
+        return
+    idx = 1
+    for cell_def in uep:
+        if cell_def.tag != "cell_definition":
+            logging.debug(f'--------pkpd_populate_tree_cell_defs: found unexpected child <cell_definitions>; skip over {cell_def}')
+            continue
+        if cell_def.tag == "cell_rules":
+            logging.debug(f'--------pkpd_populate_tree_cell_defs: found cell_rules child; break out on {cell_def}')
+            continue
+        cell_def_name = cell_def.attrib['name']
+        cell_def_tab.param_d[cell_def_name]["pd"] = {}
+        jdx = 1
+        for substrate in cell_def_tab.substrate_list:
+            cell_def_tab.param_d[cell_def_name]["pd"][substrate] = {}
+            if substrate in cell_def_tab.pd_substrates:
+                cell_def_tab.param_d[cell_def_name]['custom_data'][f'{substrate}_damage'] = ["0.0",False]
+            if idx == 1 and jdx == 1:
+                cell_def_tab.current_pd_substrate = substrate
+            jdx += 1
+        uep_pd = cell_def_tab.xml_root.find(".//cell_definitions//cell_definition[" + str(idx) + "]//PD")
+        idx += 1
+        if uep_pd is None:
+            continue
+        for substrate in cell_def_tab.substrate_list:
+            sub_elm = uep_pd.find(f".//substrate[@name='{substrate}']")
+            if sub_elm is None:
+                continue
+            pd_model = "None"
+            pd_model_elm = sub_elm.find(".//model")
+            if pd_model_elm is not None:
+                pd_model = pd_model_elm.text
+            cell_def_tab.param_d[cell_def_name]["pd"][substrate]["pd_model"] = pd_model
+            if pd_model != "None":
+                cell_def_tab.add_custom_data(f'{substrate}_damage',"0.0",False,"damage",f'Accumulated damage due to {substrate}')
+                if substrate not in cell_def_tab.pd_substrates:
+                    cell_def_tab.pd_substrates.append(substrate)
+            if substrate in cell_def_tab.pd_substrates:
+                cell_def_tab.param_d[cell_def_name]['custom_data'][f'{substrate}_damage'] = ["0.0",False]
+
+            metabolism_rate = "0"
+            metabolism_rate_elm = sub_elm.find(".//metabolism_rate")
+            if metabolism_rate_elm is not None:
+                metabolism_rate = metabolism_rate_elm.text
+            cell_def_tab.param_d[cell_def_name]["pd"][substrate]["metabolism_rate"] = metabolism_rate
+
+            constant_repair_rate = "0"
+            constant_repair_rate_elm = sub_elm.find(".//constant_repair_rate")
+            if constant_repair_rate_elm is not None:
+                constant_repair_rate = constant_repair_rate_elm.text
+            cell_def_tab.param_d[cell_def_name]["pd"][substrate]["constant_repair_rate"] = constant_repair_rate
+            
+            linear_repair_rate = "0"
+            linear_repair_rate_elm = sub_elm.find(".//linear_repair_rate")
+            if linear_repair_rate_elm is not None:
+                linear_repair_rate = linear_repair_rate_elm.text
+            cell_def_tab.param_d[cell_def_name]["pd"][substrate]["linear_repair_rate"] = linear_repair_rate
+            
+            precompute = "true"
+            precompute_elm = sub_elm.find(".//precompute")
+            if precompute_elm is not None:
+                precompute = precompute_elm.text
+            cell_def_tab.param_d[cell_def_name]["pd"][substrate]["precompute"] = precompute
+            
+            dt = "0.01" # default to default diffusion_dt
+            dt_elm = sub_elm.find(".//dt")
+            if dt_elm is not None:
+                dt = dt_elm.text
+            cell_def_tab.param_d[cell_def_name]["pd"][substrate]["dt"] = dt
+
+def populate_tree_cell_defs(cell_def_tab, skip_validate, pkpd_flag=False):
     logging.debug(f'=======================  populate_tree_cell_defs(): ======================= ')
     logging.debug(f'    cell_def_tab.param_d = {cell_def_tab.param_d}')
     # cell_def_tab.master_custom_varname.clear()
@@ -1222,6 +1293,7 @@ def populate_tree_cell_defs(cell_def_tab, skip_validate):
             else:
                 cell_def_tab.param_d[cell_def_name]["par_dists_disabled"] = True
 
+        pkpd_populate_tree_cell_defs(cell_def_tab, uep, pkpd_flag)
     # print("populate_tree_cell_defs.py:  Setting 0th cell")
     cell_def_tab.current_cell_def = cell_def_0th
     cell_def_tab.tree.setCurrentItem(cell_def_tab.tree.topLevelItem(0))  # select the top (0th) item

--- a/bin/studio.py
+++ b/bin/studio.py
@@ -96,8 +96,42 @@ def quit_cb():
     global studio_app
     studio_app.quit()
 
+def xml_has_pkpd_elements(xml_root):
+    return xml_root.find(".//PK") is not None or xml_root.find(".//PD") is not None
+
+def pkpd_not_found_notice():
+    msgBox = QMessageBox()
+    msgBox.setIcon(QMessageBox.Warning)
+    msgBox.setTextFormat(Qt.RichText)
+    msgBox.setText("The --pkpd flag was passed, but no PhysiPKPD elements (&lt;PK&gt; or &lt;PD&gt;) were found in this config file. "
+                    "This may mean PhysiPKPD was not included when your project was compiled. "
+                    "Visit <a href=\"https://github.com/drbergman-lab/PhysiPKPD.git\">https://github.com/drbergman-lab/PhysiPKPD.git</a> to add PhysiPKPD to your project.")
+    msgBox.setStandardButtons(QMessageBox.Ok)
+    msgBox.exec()
+
+def pkpd_flag_missing_notice():
+    msgBox = QMessageBox()
+    msgBox.setIcon(QMessageBox.Warning)
+    msgBox.setTextFormat(Qt.PlainText)
+    msgBox.setText("This config file contains PhysiPKPD elements (<PK> and/or <PD>), but Studio was launched without the --pkpd flag. "
+                    "You will not be able to view or edit these parameters, and saving from this session will permanently remove them from the file. "
+                    "Re-launch with --pkpd to preserve and edit them.")
+    msgBox.setStandardButtons(QMessageBox.Ok)
+    msgBox.exec()
+
+def confirm_save_without_pkpd():
+    msgBox = QMessageBox()
+    msgBox.setIcon(QMessageBox.Warning)
+    msgBox.setTextFormat(Qt.PlainText)
+    msgBox.setText("This config file contains PhysiPKPD elements (<PK> and/or <PD>), but Studio was launched without the --pkpd flag. "
+                    "Saving now will permanently remove those elements from the file. "
+                    "Cancel and re-launch with --pkpd if you want to keep them.")
+    msgBox.setStandardButtons(QMessageBox.Ok | QMessageBox.Cancel)
+    msgBox.setDefaultButton(QMessageBox.Cancel)
+    return msgBox.exec() == QMessageBox.Ok
+
 class PhysiCellXMLCreator(QWidget):
-    def __init__(self, config_file, studio_flag, skip_validate_flag, rules_flag, model3D_flag, tensor_flag, exec_file, nanohub_flag, galaxy_flag, is_movable_flag, pytest_flag, biwt_flag, samples_flag, parent = None):
+    def __init__(self, config_file, studio_flag, skip_validate_flag, rules_flag, model3D_flag, tensor_flag, exec_file, nanohub_flag, galaxy_flag, is_movable_flag, pytest_flag, biwt_flag, samples_flag, pkpd_flag, parent = None):
         super(PhysiCellXMLCreator, self).__init__(parent)
         QLocale.setDefault(QLocale(QLocale.English, QLocale.UnitedStates))
         if model3D_flag:
@@ -127,6 +161,7 @@ class PhysiCellXMLCreator(QWidget):
         self.ecm_flag = False 
         self.pytest_flag = pytest_flag 
         self.biwt_flag = biwt_flag
+        self.pkpd_flag = pkpd_flag
         self.samples_flag = samples_flag
 
         self.rules_tab_index = None
@@ -211,7 +246,12 @@ class PhysiCellXMLCreator(QWidget):
             sys.exit(-1)
 
         self.xml_root = self.tree.getroot()
-        # print(f"studio: (default) self.xml_root = {self.xml_root}")   
+        # print(f"studio: (default) self.xml_root = {self.xml_root}")
+
+        if self.pkpd_flag and not xml_has_pkpd_elements(self.xml_root):
+            pkpd_not_found_notice()
+        elif not self.pkpd_flag and xml_has_pkpd_elements(self.xml_root):
+            pkpd_flag_missing_notice()
 
         self.num_models = 0
         self.model = {}  # key: name, value:[read-only, tree]
@@ -231,7 +271,7 @@ class PhysiCellXMLCreator(QWidget):
             self.config_tab.folder.setText('.')
             self.config_tab.csv_folder.setEnabled(False)
 
-        self.microenv_tab = SubstrateDef(self.config_tab)
+        self.microenv_tab = SubstrateDef(self.config_tab, self.pkpd_flag)
         self.microenv_tab_index = 1
         self.microenv_tab.xml_root = self.xml_root
         substrate_name = self.microenv_tab.first_substrate_name()
@@ -248,10 +288,11 @@ class PhysiCellXMLCreator(QWidget):
         logging.debug(f'studio.py: first_cell_def_name= {cd_name}')
         self.celldef_tab.config_path = self.current_xml_file
 
+
         self.celldef_tab.fill_substrates_comboboxes() # do before populate? Yes, assuming we check for cell_def != None
 
         # Beware: this may set the substrate chosen for Motility/[Advanced]Chemotaxis
-        populate_tree_cell_defs(self.celldef_tab, self.skip_validate_flag)
+        populate_tree_cell_defs(self.celldef_tab, self.skip_validate_flag, pkpd_flag=self.pkpd_flag)
         # self.celldef_tab.customdata.param_d = self.celldef_tab.param_d
 
 
@@ -609,6 +650,12 @@ PhysiCell Studio is provided "AS IS" without warranty of any kind. &nbsp; In no 
         # print(f"\nreset_xml_root() self.tree = {self.tree}")
         self.xml_root = self.tree.getroot()
         # print(f"reset_xml_root() self.xml_root = {self.xml_root}")
+
+        if self.pkpd_flag and not xml_has_pkpd_elements(self.xml_root):
+            pkpd_not_found_notice()
+        elif not self.pkpd_flag and xml_has_pkpd_elements(self.xml_root):
+            pkpd_flag_missing_notice()
+
         self.config_tab.xml_root = self.xml_root
         self.microenv_tab.xml_root = self.xml_root
         self.celldef_tab.xml_root = self.xml_root
@@ -630,7 +677,7 @@ PhysiCell Studio is provided "AS IS" without warranty of any kind. &nbsp; In no 
 
         self.celldef_tab.config_path = self.current_xml_file
         self.celldef_tab.fill_substrates_comboboxes()   # do before populate_tree_cell_defs
-        populate_tree_cell_defs(self.celldef_tab, self.skip_validate_flag)
+        populate_tree_cell_defs(self.celldef_tab, self.skip_validate_flag, pkpd_flag=self.pkpd_flag)
 
         self.celldef_tab.fill_celltypes_comboboxes()
 
@@ -807,6 +854,10 @@ PhysiCell Studio is provided "AS IS" without warranty of any kind. &nbsp; In no 
 
     #---------------------------------
     def update_xml_from_gui(self):
+        if not self.pkpd_flag and xml_has_pkpd_elements(self.xml_root):
+            if not confirm_save_without_pkpd():
+                return False
+
         if not self.user_params_tab.validate_utable():
             self.run_tab.enable_run(True)
             return False
@@ -1521,6 +1572,7 @@ def main():
     is_movable_flag = False
     pytest_flag = False
     biwt_flag = False
+    pkpd_flag = False
     samples_flag = False
     try:
         parser = argparse.ArgumentParser(description='PhysiCell Studio.')
@@ -1535,6 +1587,7 @@ def main():
         parser.add_argument("-c ", "--config", type=str, help="config file (.xml)")
         parser.add_argument("-e ", "--exec", type=str, help="executable model")
         parser.add_argument("--bioinf_import","--biwt", dest="biwt_flag", help="display bioinformatics walkthrough tab on ICs tab", action="store_true")
+        parser.add_argument("--pkpd", help="display PK and PD tabs", action="store_true")
         parser.add_argument("--s","--samples", dest="samples_flag", help="menu for sample projects", action="store_true")
 
         if platform.system() == "Windows":
@@ -1600,6 +1653,8 @@ def main():
                 sys.exit()
         if args.biwt_flag:
             biwt_flag = True
+        if args.pkpd:
+            pkpd_flag = True
         if args.samples_flag:
             samples_flag = True
     except:
@@ -1674,7 +1729,7 @@ def main():
             sys.exit(1)
             # print("Warning: Rules module not found.\n")
 
-    ex = PhysiCellXMLCreator(config_file, studio_flag, skip_validate_flag, rules_flag, model3D_flag, tensor_flag, exec_file, nanohub_flag, galaxy_flag, is_movable_flag, pytest_flag, biwt_flag, samples_flag)
+    ex = PhysiCellXMLCreator(config_file, studio_flag, skip_validate_flag, rules_flag, model3D_flag, tensor_flag, exec_file, nanohub_flag, galaxy_flag, is_movable_flag, pytest_flag, biwt_flag, samples_flag, pkpd_flag)
     # print("size=",ex.size())
 
     # -- Insanity. Trying/failing to force the proper display of (default) checkboxes

--- a/bin/studio_classes.py
+++ b/bin/studio_classes.py
@@ -1,4 +1,5 @@
 import sys
+import os
 
 from PyQt5 import QtCore
 from PyQt5.QtCore import Qt, QEvent, QTimer
@@ -225,7 +226,19 @@ class QRadioButton_custom(QRadioButton):
 class QComboBox_custom(QComboBox):
     def __init__(self):
         super().__init__()
-        self.setStyleSheet("QComboBox{color: #000000; background-color: #FFFFFF;}")
+
+        combobox_style = """
+        QComboBox {
+            color: black;
+            background-color: white;
+        }
+        QComboBox:disabled {
+            color: black;
+            background-color:lightgray;
+        }
+        """
+        self.setStyleSheet(combobox_style)
+
 class ExtendedCombo( QComboBox ):
     def __init__( self,  parent = None):
         super( ExtendedCombo, self ).__init__( parent )
@@ -475,3 +488,24 @@ class DoubleValidatorOpenInterval(QDoubleValidator):
                 state = QDoubleValidator.Intermediate
 
         return state, value, pos
+
+##### Custom validators
+
+class FolderPathValidator(QValidator):
+    def validate(self, string, pos):
+        if os.path.isdir(string):
+            return QValidator.Acceptable, string, pos
+        else:
+            return QValidator.Intermediate, string, pos
+
+class FileNameValidator(QValidator):
+    def __init__(self, folder_line_edit):
+        super().__init__()
+        self.folder_line_edit = folder_line_edit
+
+    def validate(self, string, pos):
+        folder = self.folder_line_edit.text()
+        if os.path.isfile(os.path.join(folder, string)):
+            return QValidator.Acceptable, string, pos
+        else:
+            return QValidator.Intermediate, string, pos

--- a/bin/vis_base.py
+++ b/bin/vis_base.py
@@ -1739,7 +1739,7 @@ class VisBase():
         self.celldef_tab.config_path = config_file
         self.celldef_tab.fill_substrates_comboboxes()   # do before populate_tree_cell_defs
         # populate_tree_cell_defs(self.celldef_tab, self.skip_validate_flag)
-        populate_tree_cell_defs(self.celldef_tab, False)
+        populate_tree_cell_defs(self.celldef_tab, False, pkpd_flag=self.celldef_tab.pkpd_flag)
 
         self.celldef_tab.fill_celltypes_comboboxes()
 


### PR DESCRIPTION
## Summary

Adds optional support for editing [PhysiPKPD](https://github.com/drbergman-lab/PhysiPKPD.git) (pharmacokinetics/pharmacodynamics) parameters in the Studio, behind a new `--pkpd` command-line flag.

- **PK tab** in the Microenvironment editor — one per substrate, for configuring pharmacokinetic dynamics (constant, one/two-compartment, or SBML-driven PK models, dosing schedules, elimination/exchange rates, etc.).
- **PD section** in the Cell Types editor — one per substrate, for configuring pharmacodynamic damage/repair models (AUC, AUC_amount) tied to that substrate, including an auto-managed `<substrate>_damage` custom data variable.
- Full XML read/write support for the new `<PK>` and `<PD>` elements.
- Guardrails to keep the flag and the file's contents from getting out of sync:
  - A warning if `--pkpd` is passed but the loaded config has no `<PK>`/`<PD>` elements anywhere, since that could mean the project executable wasn't compiled against PhysiPKPD (or the model just hasn't been configured yet) — the message links to the PhysiPKPD repo.
  - A warning if the loaded config *does* have `<PK>`/`<PD>` elements but `--pkpd` was **not** passed, explaining that those elements will be silently dropped if the file is saved from this session (since PK/PD data is only ever read into memory when the flag is set — see below).
  - Save and Save As will additionally block on a Cancel-by-default confirmation in that same situation, so PhysiPKPD parameters can't be lost by an accidental save — a user has to explicitly confirm before that data is removed.

## How to access it

```
python bin/studio.py --pkpd -c path/to/PhysiCell_settings.xml
```

Without `--pkpd`, Studio behaves exactly as it does today — no new UI, no new XML output. The one exception is the two warnings/save-confirmation above, which only appear when a loaded file's `<PK>`/`<PD>` content and the `--pkpd` flag disagree; if there's no PhysiPKPD content in the file, nothing changes. The flag itself is entirely opt-in.

## Backwards compatibility

Every change is either inert unless `--pkpd`/`self.pkpd_flag` is set, or a behavior-preserving refactor:

- **New PK/PD UI** (`create_pk_tab`, `create_pd_tab`, and related callbacks) is only constructed and only shown when `pkpd_flag` is `True`.
- **`add_new_celltype(cdname, reset_mapping=True)`** — the new `reset_mapping` kwarg only has an effect inside `if reset_mapping is True and self.pkpd_flag is True:`, so it's a no-op for every existing caller when `--pkpd` isn't passed.
- **`add_new_substrate(sub_name, sub_to_copy)`** — the new `sub_to_copy` argument is only consumed inside `pkpd_add_new_substrate`, itself gated by `if self.pkpd_flag`. Both real call sites (new substrate / copy substrate) were updated to pass it correctly.
- **`add_custom_data`, `delete_custom_data_row`** — new helper methods used exclusively by the PD auto-add/remove-damage-variable logic, which itself only runs when `pkpd_flag` is set.
- **`delete_key_from_master_custom_var_d`** — extracted verbatim from the existing inline body of `delete_custom_data_cb` (used by the "Delete parameter" button in the Custom Data tab); confirmed line-for-line equivalent, not a behavior change.
- **`populate_tree_cell_defs(..., pkpd_flag=False)`** — new parameter defaults to `False` and is threaded through unchanged for all existing callers; `pkpd_populate_tree_cell_defs()` early-returns when the flag is off. (`vis_base.py`'s only change is threading this same flag through its own call to `populate_tree_cell_defs`.)
- The two new load-time warnings and the save-time confirmation only trigger when a file's `<PK>`/`<PD>` content and `--pkpd` disagree — a file with no PhysiPKPD content behaves identically to today regardless of the flag.
- No changes to XML written for models that don't use PhysiPKPD.

This was reviewed specifically for regression risk before opening the PR — every changed/added function was traced to its call sites to confirm base-Studio (non-`--pkpd`) behavior is unchanged.

## Testing

- Verified `bin/studio.py --help` shows the new `--pkpd` flag with no change to existing flags.
- Launched Studio with and without `--pkpd` against the default template config (which has no `<PK>`/`<PD>` elements) and confirmed no PK/PD UI and no warnings appear without the flag, and the PK/PD UI appears with it.
- Programmatically verified all four combinations of (`--pkpd` on/off) × (file has/doesn't have `<PK>`/`<PD>`) trigger exactly the right one of: no warning, "flag passed but nothing found," "found but flag missing," by calling the check functions directly against parsed configs.
- Programmatically verified `confirm_save_without_pkpd()` returns `False`/`True` for simulated Cancel/Ok clicks, gating the save.
- Constructed the real `SubstrateDef` widget in a headless PyQt session and drove it through PK model/schedule-format changes (including a tree-switch ordering edge case) to confirm the CSV folder/filename fields are enabled only when schedule format is "csv".
- All touched files pass `python -m py_compile`.
