### PR TITLE
Studio owns the config XML BIWT 0.6 no longer generates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,7 @@ RUN chmod +x /startapp.sh
 COPY ./bin/* /opt/pcstudio/bin/
 COPY ./bin/images/* /opt/pcstudio/bin/images/
 COPY ./bin/icon/* /opt/pcstudio/bin/icon/
+COPY ./bin/cell_templates/* /opt/pcstudio/bin/cell_templates/
 COPY ./bin/BIWT_parameters* /opt/pcstudio/bin/BIWT_parameters
 COPY ./config/* /opt/pcstudio/config/
 COPY ./samples/* /opt/pcstudio/samples/

--- a/bin/BIWT_parameters/xml_defaults.py
+++ b/bin/BIWT_parameters/xml_defaults.py
@@ -1,89 +1,24 @@
-xml_defaults = {
+"""
+xml_defaults.py - config defaults for the deprecated in-tree BIWT tab (bin/biwt_tab.py).
 
-    "domain": """
-            <x_min>-500</x_min>
-            <x_max>500</x_max>
-            <y_min>-500</y_min>
-            <y_max>500</y_max>
-            <z_min>-10</z_min>
-            <z_max>10</z_max>
-            <dx>20</dx>
-            <dy>20</dy>
-            <dz>20</dz>
-            <use_2D>true</use_2D>
-    """,
+The sections themselves now live in bin/physicell_xml_defaults.py, which the current BIWT
+bridge uses. This module only rebuilds the dict in the shape biwt_tab.add_xml_defaults()
+expects: the same ten keys in the same order, with "cell_definitions" between
+"microenvironment_setup" and "initial_conditions". add_xml_defaults() iterates .items() and
+appends each in turn, so the order here is the order of the file it writes.
 
-    "overall": """
-            <max_time units="min">7200</max_time>
-            <time_units>min</time_units>
-            <space_units>micron</space_units>
-            <dt_diffusion units="min">0.01</dt_diffusion>
-            <dt_mechanics units="min">0.1</dt_mechanics>
-            <dt_phenotype units="min">6</dt_phenotype>
-    """,
+Nothing new should import this. When the deprecated tab goes, so does bin/BIWT_parameters/.
+"""
 
-    "parallel": """
-            <omp_num_threads>4</omp_num_threads>
-    """,
+from physicell_xml_defaults import XML_DEFAULT_SECTIONS, CELL_DEFINITIONS_AFTER
 
-    "save":
-      """
-            <folder>output</folder>
-            <full_data>
-                <interval units="min">60</interval>
-                <enable>true</enable>
-            </full_data>
-            <SVG>
-                <interval units="min">60</interval>
-                <enable>true</enable>
-                <plot_substrate enabled="false" limits="false">
-                    <substrate>substrate</substrate>
-                    <min_conc />
-                    <max_conc />
-                </plot_substrate>
-            </SVG>
-            <legacy_data>
-                <enable>false</enable>
-            </legacy_data>
-    """,
 
-    "options": """
-            <legacy_random_points_on_sphere_in_divide>false</legacy_random_points_on_sphere_in_divide>
-            <virtual_wall_at_domain_edge>true</virtual_wall_at_domain_edge>
-            <disable_automated_spring_adhesions>false</disable_automated_spring_adhesions>
-            <random_seed>0</random_seed>
-        """,
-        
-    "microenvironment_setup":"""
-            <variable name="substrate" units="dimensionless" ID="0">
-                <physical_parameter_set>
-                    <diffusion_coefficient units="micron^2/min">100000.0</diffusion_coefficient>
-                    <decay_rate units="1/min">10</decay_rate>
-                </physical_parameter_set>
-                <initial_condition units="mmHg">0</initial_condition>
-                <Dirichlet_boundary_condition units="mmHg" enabled="False">0</Dirichlet_boundary_condition>
-                <Dirichlet_options>
-                    <boundary_value ID="xmin" enabled="False">0</boundary_value>
-                    <boundary_value ID="xmax" enabled="False">0</boundary_value>
-                    <boundary_value ID="ymin" enabled="False">0</boundary_value>
-                    <boundary_value ID="ymax" enabled="False">0</boundary_value>
-                    <boundary_value ID="zmin" enabled="False">0</boundary_value>
-                    <boundary_value ID="zmax" enabled="False">0</boundary_value>
-                </Dirichlet_options>
-            </variable>
-            <options>
-                <calculate_gradients>true</calculate_gradients>
-                <track_internalized_substrates_in_each_agent>true</track_internalized_substrates_in_each_agent>
-                <initial_condition type="matlab" enabled="false">
-                    <filename>./config/initial.mat</filename>
-                </initial_condition>
-                <dirichlet_nodes type="matlab" enabled="false">
-                    <filename>./config/dirichlet.mat</filename>
-                </dirichlet_nodes>
-            </options>
-        """,
-
-    "cell_definitions": """
+# The <cell_definition name="default"> the deprecated tab appends to the file it writes.
+# Verbatim, so that tab's output is unchanged. It carries Cortex_1/Dentate_gyrus/...
+# asymmetric-division probabilities baked in from one mouse-brain dataset, which is why it
+# sits here rather than with the sections every config shares: deleting this directory has
+# to delete it too.
+LEGACY_DEFAULT_CELL_DEFINITION = """
         <cell_definition name="default" ID="0">
                 <phenotype>
                     <cycle code="6" name="Flow cytometry model (separated)">
@@ -312,26 +247,11 @@ xml_defaults = {
                     </distribution>
                 </initial_parameter_distributions>
             </cell_definition>
-        """,
+        """
 
-    "initial_conditions": """
-            <cell_positions type="csv" enabled="true">
-                <folder>./config</folder>
-                <filename>cells.csv</filename>
-            </cell_positions>
-    """,
-
-    "cell_rules": """
-            <rulesets>
-                <ruleset protocol="CBHG" version="3.0" format="csv" enabled="false">
-                    <folder>./config</folder>
-                    <filename>rules0.csv</filename>
-                </ruleset>
-            </rulesets>
-            <settings />
-    """,
-
-    "user_parameters": """
-            <number_of_cells type="int" units="none" description="initial number of cells (for each cell type)">5</number_of_cells>
-    """
-}
+xml_defaults = {}
+for _key, _fragment in XML_DEFAULT_SECTIONS.items():
+    xml_defaults[_key] = _fragment
+    if _key == CELL_DEFINITIONS_AFTER:
+        xml_defaults["cell_definitions"] = LEGACY_DEFAULT_CELL_DEFINITION
+del _key, _fragment

--- a/bin/biwt_bridge.py
+++ b/bin/biwt_bridge.py
@@ -1,0 +1,965 @@
+"""
+biwt_bridge.py - turn what BIWT returns into cell definitions this model can hold.
+
+BiwtResult.cell_templates is {cell type: (path, template name, content)}, one entry per cell
+type the walkthrough assigned a template to. `content` is a <phenotype> block verbatim from a
+.toml library -- except when `path` is biwt.types.HOST_SOURCE, which means the user picked one
+of this model's own cell types: no content, and `template name` is the cell type to copy.
+
+A template knows nothing about the model it is joining, so it names substrates and cell types
+that may not exist here, and it carries no name or ID of its own. Everything in this module
+exists to close that gap before the XML reaches Studio's config.
+
+No PyQt5 -- this is all ElementTree and csv, so the rules below can be tested
+without standing up a QApplication. The dialogs live in biwt_bridge_ui.py.
+
+Three things here are load-bearing rather than tidy, all of them because of how
+populate_tree_cell_defs.py and cell_def_tab.py read a config back in:
+
+  * IDs must come out 0..N-1. With "auto number IDs when saved" unticked -- its default --
+    cell_def_tab.fill_xml() walks `for count in range(len(param_d))` and emits only the cell
+    def whose ID is `count`, so a gap or a duplicate silently drops a cell type from the file
+    the next time the user saves.
+  * <secretion> must name exactly the substrates the model has. fill_xml_secretion() iterates
+    the model's substrate list and indexes param_d[cdef]["secretion"][substrate], which
+    populate_tree_cell_defs fills *from the XML* -- so a missing entry is a modal error
+    dialog per substrate per cell type, not a default.
+  * A cell definition missing a phenotype section takes Studio down: validate_cell_defs()
+    and handle_parse_error() both end in sys.exit(-1). Hence repair_cell_defs().
+
+Authors:
+Dr. Daniel Bergman
+Rf. Credits.md
+"""
+
+import copy
+import csv
+import os
+import xml.etree.ElementTree as ET
+
+import physicell_xml_defaults as pcdefaults
+import rules_tokens
+import xml_validate
+
+try:
+    from biwt.types import HOST_SOURCE
+except Exception:
+    # Only for importing this module without BIWT, e.g. to unit-test the XML rules. BIWT
+    # documents the value as reserved and deliberately not a usable path.
+    HOST_SOURCE = "<host>"
+
+
+# Values a cell definition gets for something it never mentioned. These match
+# cell_def_tab.new_secretion_params() and new_mechanics_params() so that a cell type
+# reconciled here is indistinguishable from one the user added by hand.
+ZERO_SECRETION = (
+    ("secretion_rate", "0.0", "1/min"),
+    ("secretion_target", "1.0", "substrate density"),
+    ("uptake_rate", "0.0", "1/min"),
+    ("net_export_rate", "0.0", "total substrate/min"),
+)
+DEFAULT_AFFINITY = "1.0"
+DEFAULT_RATE = "0.0"
+DEFAULT_SENSITIVITY = "0.0"
+
+# The phenotype template library Studio ships, and the one it expects BIWT to have drawn
+# from. Compared against the path BIWT reports so that phenotypes sourced from somewhere
+# else are visible in the dialog rather than something the user has to infer.
+BUNDLED_TEMPLATE_LIBRARY = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "cell_templates", "cell_templates.toml")
+
+
+def is_bundled_library(path):
+    if not path:
+        return False
+    try:
+        return os.path.samefile(path, BUNDLED_TEMPLATE_LIBRARY)
+    except OSError:
+        return os.path.abspath(path) == BUNDLED_TEMPLATE_LIBRARY
+
+# BiwtResult.cell_templates is the field as of BIWT 0.5: {cell type: (path, name, content)}.
+# The others are tried only so that a rename on BIWT's side degrades to a named problem in
+# the dialog rather than a silent "BIWT sent nothing".
+_CELL_DEF_ATTRS = (
+    "cell_templates",
+    "cell_definitions",
+    "cell_defs",
+)
+
+
+# What a cell definition was actually built from, once resolved.
+ORIGIN_TEMPLATE = "template"   # a template out of a .toml library
+ORIGIN_HOST = "host"           # this model's own definition of another cell type
+ORIGIN_DEFAULT = "default"     # Studio's default phenotype
+
+
+class CellDefRequest:
+    """One cell type BIWT asked Studio to build, and what it was built from.
+
+    A request outlives content it cannot use: a template that will not parse is kept, with the
+    reason in `error`, so the cell type is still reported as one a template was chosen for.
+
+    Filled out in three passes: extract_cell_defs() records what BIWT said, resolve_cell_defs()
+    produces `element` and `origin`, repair_cell_defs() fills any phenotype section still
+    missing and records it in `filled`.
+    """
+
+    __slots__ = ("name", "source", "template_name", "content",
+                 "element", "origin", "error", "filled")
+
+    def __init__(self, name, source=None, template_name=None, content=""):
+        self.name = name
+        self.source = source                # a .toml path, HOST_SOURCE, or None
+        self.template_name = template_name  # key in that file, or the host cell type
+        self.content = content or ""
+        self.element = None                 # set by resolve_cell_defs()
+        self.origin = None                  # one of the ORIGIN_* values, likewise
+        self.error = None                   # why `content` was unusable, if it was
+        self.filled = []                    # phenotype paths taken from Studio's defaults
+
+    def __repr__(self):
+        return "CellDefRequest(%r, origin=%r, error=%r)" % (self.name, self.origin, self.error)
+
+    def chose_template(self):
+        """True if a template was named at all -- as opposed to left at "(none)"."""
+        return self.template_name is not None
+
+    def from_host(self):
+        return self.source == HOST_SOURCE
+
+    def describe_template(self):
+        """The template as the user chose it, for the dialog. Empty if none was chosen."""
+        if not self.chose_template():
+            return ""
+        if self.from_host():
+            return 'this model\'s "%s"' % self.template_name
+        if self.source:
+            return '"%s" from %s' % (self.template_name, os.path.basename(self.source))
+        return '"%s"' % self.template_name
+
+
+class ReconcileReport:
+    """What reconcile_cell_def() had to invent, for the receipt to name.
+
+    Only what a user can act on. Reconciliation rewrites much more -- the chemotaxis target,
+    every cell-type-keyed rate, the custom data -- but those come out either right or as the
+    model's own values. A substrate left at zero is a real gap only the user can fill.
+    """
+
+    def __init__(self, name):
+        self.name = name
+        self.substrates_zeroed = []         # no values for these, from BIWT or the model
+        self.dropped_cell_type_refs = []    # (container_tag, name), for the caller's summary
+
+
+# ---------------------------------------------------------------------------
+# Reading BIWT's result
+# ---------------------------------------------------------------------------
+
+def _looks_like_cell_defs(value):
+    """True for a {name: content} mapping, false for BIWT's other dicts.
+
+    cell_type_map is the one to keep out: it is {str: str|None} and would otherwise pass.
+    """
+    if not isinstance(value, dict) or not value:
+        return False
+    for key, item in value.items():
+        if not isinstance(key, str):
+            return False
+        if isinstance(item, (tuple, list)):
+            if len(item) != 3:
+                return False
+        elif not isinstance(item, (str, ET.Element)):
+            return False
+    return True
+
+
+def _find_cell_def_payload(result):
+    """The cell templates off *result*, or None."""
+    for attr in _CELL_DEF_ATTRS:
+        value = getattr(result, attr, None)
+        if _looks_like_cell_defs(value):
+            return value
+
+    # No known name matched: accept any attribute shaped like the mapping, so a renamed field
+    # still yields cell types instead of an empty result.
+    for attr, value in sorted(vars(result).items()) if hasattr(result, "__dict__") else ():
+        if attr == "cell_type_map":
+            continue
+        if _looks_like_cell_defs(value):
+            return value
+    return None
+
+
+def _parse_content(content):
+    """A <cell_definition> from template content, or (None, why it could not be used)."""
+    if isinstance(content, ET.Element):
+        return copy.deepcopy(content), None
+
+    text = (content or "").strip()
+    if not text:
+        return None, None          # nothing supplied; not a failure
+    try:
+        element = ET.fromstring(text)
+    except ET.ParseError as e:
+        return None, "will not parse as XML (%s)" % e
+
+    if element.tag == "cell_definition":
+        return element, None
+    if element.tag == "phenotype":
+        # A template may hold just the phenotype; wrap it. assign_names_and_ids() and
+        # inject_cell_defs() write name and ID, so their absence here costs nothing.
+        wrapper = ET.Element("cell_definition")
+        wrapper.append(element)
+        return wrapper, None
+
+    nested = element.find(".//cell_definition")
+    if nested is not None:
+        return copy.deepcopy(nested), None
+
+    return None, "is not a cell definition (its root element is <%s>)" % element.tag
+
+
+def extract_cell_defs(result):
+    """Read BIWT's result into {name: CellDefRequest}.
+
+    Records what BIWT said and nothing more -- see resolve_cell_defs() for turning that into
+    XML. Nothing raises and nothing is discarded: content that will not parse is kept on the
+    request as `error`, so the cell type is still reported as one a template was chosen for.
+    """
+    requests = {}
+    if result is None:
+        return requests
+
+    payload = _find_cell_def_payload(result)
+    if payload is None:
+        return requests
+
+    for key, value in payload.items():
+        name = (key or "").strip()
+        if not name or name in requests:
+            # A blank name, or two that collide once trimmed. Neither can be built, and
+            # neither is something the user can act on from here.
+            continue
+
+        source = template_name = None
+        content = value
+        if isinstance(value, (tuple, list)):
+            source, template_name, content = value
+
+        request = CellDefRequest(name, source, template_name, content)
+        if not request.from_host():
+            request.element, request.error = _parse_content(content)
+        requests[name] = request
+
+    return requests
+
+
+def request_for_csv_type(name):
+    """A request for a cell type the .csv places that BIWT assigned no template to."""
+    return CellDefRequest(name)
+
+
+def resolve_cell_defs(requests, cell_definitions_elm=None, nanohub_flag=False, data_dir=None):
+    """Give every request an `element` and an `origin`.
+
+    Three ways a cell definition gets built, in order of what was asked for:
+
+      * the user picked one of this model's own cell types -- copy that definition. It is a
+        copy, not a rename: the new type keeps the name BIWT returned, so the host type stays
+        and the copy starts out identical. The copy is taken from the tree as loaded;
+        recopy_host_definitions() refreshes it from the tree as it will be written.
+      * a library template that parsed -- use it as-is.
+      * anything else -- Studio's default phenotype. That covers a template that would not
+        parse, a host cell type since renamed or deleted, and a type left at "(none)". `error`
+        says which, and stays set so the dialog can distinguish them.
+    """
+    by_name = {}
+    if cell_definitions_elm is not None:
+        by_name = {cd.attrib.get("name"): cd
+                   for cd in cell_definitions_elm.findall("cell_definition")}
+
+    for request in requests.values():
+        if request.origin is not None:
+            # biwt_bridge_ui._resolve() runs this twice; on the second pass the element built
+            # here would otherwise read as "a template that parsed" and relabel an
+            # ORIGIN_DEFAULT request ORIGIN_TEMPLATE.
+            continue
+
+        if request.from_host():
+            source = by_name.get(request.template_name)
+            if source is not None:
+                request.element = copy.deepcopy(source)
+                request.origin = ORIGIN_HOST
+            else:
+                request.error = "is no longer in this model"
+        elif request.element is not None:
+            request.origin = ORIGIN_TEMPLATE
+
+        if request.element is None:
+            request.element = ET.Element("cell_definition")
+            request.element.append(pcdefaults.default_phenotype(nanohub_flag, data_dir))
+            request.origin = ORIGIN_DEFAULT
+
+        request.element.attrib["name"] = request.name
+
+    return requests
+
+
+def recopy_host_definitions(requests, cell_definitions_elm):
+    """Refresh host-sourced copies from *cell_definitions_elm*.
+
+    resolve_cell_defs() runs before the dialog, against the tree as loaded, so the dialog can
+    say where each definition will come from. The copy itself has to be taken from the tree as
+    it will be *written*: a definition the user edited without saving differs between the two.
+    """
+    if cell_definitions_elm is None:
+        return requests
+    by_name = {cd.attrib.get("name"): cd
+               for cd in cell_definitions_elm.findall("cell_definition")}
+    for request in requests.values():
+        if request.origin != ORIGIN_HOST:
+            continue
+        source = by_name.get(request.template_name)
+        if source is not None:
+            request.element = copy.deepcopy(source)
+            request.element.attrib["name"] = request.name
+            request.filled = []          # repair_cell_defs() runs again after this
+    return requests
+
+
+def repair_cell_defs(requests, default_phenotype=None, nanohub_flag=False, data_dir=None):
+    """Fill in any phenotype section a cell definition arrived without.
+
+    populate_tree_cell_defs' validate_cell_defs() and handle_parse_error() both end in
+    sys.exit(-1) on an incomplete cell definition, so every phenotype section a template omits
+    has to be filled before the XML is written. Each request records what was filled, so the
+    dialog can name the sections rather than quietly inventing parameters.
+    """
+    if default_phenotype is None:
+        default_phenotype = pcdefaults.default_phenotype(nanohub_flag, data_dir)
+
+    template = ET.Element("cell_definition")
+    template.append(default_phenotype)
+
+    for request in requests.values():
+        if request.element is None:
+            continue
+        # Appended, not assigned: biwt_bridge_ui._resolve() runs this a second time after
+        # recopy_host_definitions(), by which point the first pass's sections are present, so
+        # assigning would report every request as having needed nothing.
+        # recopy_host_definitions() clears `filled` for the rows it rebuilds.
+        for path in xml_validate.fill_missing(
+                request.element, pcdefaults.CELL_DEF_SPEC, template):
+            if path not in request.filled:
+                request.filled.append(path)
+    return requests
+
+
+def classify_names(incoming_names, existing_names):
+    """Split incoming names into (matched, added), on the stripped name alone.
+
+    The one place Studio decides whether two cell type names are the same name. No fuzzy
+    matching: "Macrophage" against an existing "macrophage" is a second cell type, not a
+    correction.
+    """
+    existing = {(name or "").strip() for name in existing_names}
+    matched, added = set(), []
+    for raw in incoming_names:
+        name = (raw or "").strip()
+        if name in existing:
+            matched.add(name)
+        else:
+            added.append(name)
+    return matched, added
+
+
+# ---------------------------------------------------------------------------
+# Substrates
+# ---------------------------------------------------------------------------
+
+def collect_referenced_substrates(defs):
+    """Every substrate the incoming cell definitions name, in first-seen order.
+
+    Anything here that the model lacks gets added to it rather than dropped: a cell type that
+    secretes or chemotaxes toward something is describing a substrate the model needs.
+
+    Named, not used: a cell definition copied out of a PhysiCell model carries a <secretion>
+    entry for every substrate that model has, nearly all at zero, so one cell type brings that
+    model's whole microenvironment into a new config. Do not trim to the non-zero rates -- a
+    rule, or a project's own C++, can tie a cell type to a substrate whose XML rates are all 0,
+    and neither is visible from here.
+    """
+    found = []
+    seen = set()
+
+    def note(name):
+        name = (name or "").strip()
+        if name and name not in seen:
+            seen.add(name)
+            found.append(name)
+
+    for entry in defs.values():
+        element = entry.element
+        if element is None:
+            continue  # Unresolved: nothing to read. resolve_cell_defs() fills these in.
+        for substrate in element.findall("phenotype/secretion/substrate"):
+            note(substrate.attrib.get("name"))
+        chemotaxis = element.find("phenotype/motility/options/chemotaxis/substrate")
+        if chemotaxis is not None:
+            note(chemotaxis.text)
+        for sensitivity in element.findall(
+                "phenotype/motility/options/advanced_chemotaxis/"
+                "chemotactic_sensitivities/chemotactic_sensitivity"):
+            note(sensitivity.attrib.get("substrate"))
+
+    return found
+
+
+def new_file_substrates(requests):
+    """The microenvironment a brand-new config gets: (every substrate, the ones added).
+
+    Studio's default microenvironment, plus every substrate the incoming cell types name. A
+    new config starts from the defaults rather than from the open model, so the second list is
+    what a cell type dragged in behind it -- see collect_referenced_substrates().
+    """
+    default = model_substrates(ET.fromstring(
+        "<PhysiCell_settings><microenvironment_setup>%s</microenvironment_setup>"
+        "</PhysiCell_settings>"
+        % pcdefaults.XML_DEFAULT_SECTIONS["microenvironment_setup"].strip()))
+    extra = [name for name in collect_referenced_substrates(requests) if name not in default]
+    return default + extra, extra
+
+
+def model_substrates(xml_root):
+    """The model's substrate names, from the same place fill_substrates_comboboxes() reads."""
+    if xml_root is None:
+        return []
+    return [
+        var.attrib["name"]
+        for var in xml_root.findall(".//microenvironment_setup/variable")
+        if "name" in var.attrib
+    ]
+
+
+def model_cell_type_names(xml_root):
+    if xml_root is None:
+        return []
+    return [
+        cd.attrib["name"]
+        for cd in xml_root.findall(".//cell_definitions/cell_definition")
+        if "name" in cd.attrib
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Reconciling one cell definition against the model
+# ---------------------------------------------------------------------------
+
+def _index_by_attrib(container, tag, attrib):
+    if container is None:
+        return {}
+    return {
+        child.attrib[attrib]: child
+        for child in container.findall(tag)
+        if attrib in child.attrib
+    }
+
+
+def _replace_child(parent, old, new):
+    """Swap *old* for *new* in place, keeping its position among its siblings."""
+    if old is None:
+        parent.append(new)
+        return
+    index = list(parent).index(old)
+    parent.remove(old)
+    parent.insert(index, new)
+
+
+def _secretion_block(name, source):
+    block = ET.Element("substrate", {"name": name})
+    for tag, fallback, units in ZERO_SECRETION:
+        child = ET.SubElement(block, tag, {"units": units})
+        existing = source.find(tag) if source is not None else None
+        if existing is not None and existing.text is not None:
+            child.text = existing.text
+            if "units" in existing.attrib:
+                child.attrib["units"] = existing.attrib["units"]
+        else:
+            child.text = fallback
+    return block
+
+
+def _reconcile_secretion(element, substrates, existing_cd, report):
+    phenotype = element.find("phenotype")
+    old = phenotype.find("secretion")
+    incoming = _index_by_attrib(old, "substrate", "name")
+    existing = _index_by_attrib(
+        existing_cd.find("phenotype/secretion") if existing_cd is not None else None,
+        "substrate", "name")
+
+    new = ET.Element("secretion")
+    for name in substrates:
+        if name in incoming:
+            new.append(_secretion_block(name, incoming[name]))
+        elif name in existing:
+            new.append(_secretion_block(name, existing[name]))
+        else:
+            report.substrates_zeroed.append(name)
+            new.append(_secretion_block(name, None))
+
+    _replace_child(phenotype, old, new)
+
+
+def _reconcile_chemotaxis(element, substrates, existing_cd):
+    motility = element.find("phenotype/motility")
+    if motility is None:
+        return
+    options = motility.find("options")
+    if options is None:
+        if not substrates:
+            return
+        options = ET.SubElement(motility, "options")
+
+    chemotaxis = options.find("chemotaxis")
+    if chemotaxis is None:
+        # Absent is not safe, even though it means the same as disabled. Studio reads a
+        # missing <chemotaxis> as an empty substrate name (populate_tree_cell_defs) and
+        # writes it back out that way on the next save, and PhysiCell rejects the file:
+        # "invalid substrate was not found in the microenvironment". It insists on a real
+        # substrate whether or not chemotaxis is switched on, so name one and leave it off.
+        if not substrates:
+            return
+        chemotaxis = ET.SubElement(options, "chemotaxis")
+        xml_validate.set_text(chemotaxis, "enabled", "false")
+        xml_validate.set_text(chemotaxis, "substrate", substrates[0])
+        xml_validate.set_text(chemotaxis, "direction", "1")
+        return
+
+    substrate_elm = chemotaxis.find("substrate")
+    wanted = (substrate_elm.text or "").strip() if substrate_elm is not None else ""
+    if wanted in substrates:
+        return  # collect_referenced_substrates() should have made this the common case
+
+    fallback = ""
+    if existing_cd is not None:
+        previous = existing_cd.find("phenotype/motility/options/chemotaxis")
+        if previous is not None:
+            previous_substrate = previous.find("substrate")
+            candidate = (previous_substrate.text or "").strip() if previous_substrate is not None else ""
+            if candidate in substrates:
+                fallback = candidate
+                for tag in ("enabled", "direction"):
+                    source = previous.find(tag)
+                    if source is not None:
+                        xml_validate.set_text(chemotaxis, tag, source.text)
+
+    if not fallback and substrates:
+        fallback = substrates[0]
+        xml_validate.set_text(chemotaxis, "enabled", "false")
+
+    if not fallback:
+        # No substrates anywhere. Remove the element rather than blank the substrate:
+        # populate_tree_cell_defs handles a missing <chemotaxis>, but reads .text.lower()
+        # on the substrate it does find, and that raises on an empty one -- which lands in
+        # handle_parse_error() and exits Studio.
+        options.remove(chemotaxis)
+        return
+
+    xml_validate.set_text(chemotaxis, "substrate", fallback)
+
+
+def _reconcile_sensitivities(element, substrates, existing_cd):
+    advanced = element.find("phenotype/motility/options/advanced_chemotaxis")
+    if advanced is None:
+        return
+    old = advanced.find("chemotactic_sensitivities")
+    incoming = _index_by_attrib(old, "chemotactic_sensitivity", "substrate")
+    existing = _index_by_attrib(
+        existing_cd.find("phenotype/motility/options/advanced_chemotaxis/"
+                         "chemotactic_sensitivities") if existing_cd is not None else None,
+        "chemotactic_sensitivity", "substrate")
+
+    new = ET.Element("chemotactic_sensitivities")
+    for name in substrates:
+        source = incoming.get(name, existing.get(name))
+        child = ET.SubElement(new, "chemotactic_sensitivity", {"substrate": name})
+        child.text = source.text if source is not None and source.text else DEFAULT_SENSITIVITY
+
+    _replace_child(advanced, old, new)
+
+
+def _reconcile_keyed_by_cell_type(element, path, child_tag, roster, existing_cd,
+                                  default_value, units, report):
+    """Rewrite a container whose children are keyed by cell type name.
+
+    Same shape for adhesion affinities, phagocytosis/attack/fusion/transformation rates:
+    keep what BIWT said about a cell type this model has, fall back to what the cell
+    definition being replaced said, otherwise the default -- and drop names that are not
+    cell types here, since nothing in the GUI would ever show them again.
+    """
+    container = element.find(path)
+    if container is None:
+        return
+
+    incoming = _index_by_attrib(container, child_tag, "name")
+    existing = _index_by_attrib(
+        existing_cd.find(path) if existing_cd is not None else None, child_tag, "name")
+
+    for name in incoming:
+        if name not in roster:
+            report.dropped_cell_type_refs.append((child_tag, name))
+
+    new = ET.Element(container.tag, dict(container.attrib))
+    names = roster
+    for name in names:
+        source = incoming.get(name, existing.get(name))
+        attribs = {"name": name}
+        if units:
+            attribs["units"] = units
+        child = ET.SubElement(new, child_tag, attribs)
+        if source is not None:
+            child.text = source.text if source.text is not None else default_value
+            if units and "units" in source.attrib:
+                child.attrib["units"] = source.attrib["units"]
+        else:
+            child.text = default_value
+
+    parent_path = path.rpartition("/")[0]
+    parent = element.find(parent_path) if parent_path else element
+    _replace_child(parent, container, new)
+
+
+def _reconcile_asymmetric_division(element, roster, report):
+    """Drop probabilities naming cell types this model does not have.
+
+    Nothing is added: populate_tree_cell_defs seeds every cell type (0, or 1.0 for the cell
+    type itself) before reading the XML, so absent entries already have sensible values,
+    and inventing probabilities here would change a distribution that is meant to sum to 1.
+    """
+    container = element.find("phenotype/cycle/standard_asymmetric_division")
+    if container is None:
+        return
+    for child in list(container.findall("asymmetric_division_probability")):
+        name = child.attrib.get("name")
+        if name not in roster:
+            container.remove(child)
+            report.dropped_cell_type_refs.append(("asymmetric_division_probability", name))
+
+
+def _reconcile_custom_data(element, custom_data_src):
+    """Give a new cell type the model's custom variables.
+
+    Custom data is shared across cell types in practice -- the Cell Types > Custom Data table
+    is one table -- so a cell type arriving without any would show an empty table next to its
+    neighbours. On a new config there is no source and it correctly gets none.
+    """
+    old = element.find("custom_data")
+    if custom_data_src is None:
+        if old is None:
+            element.append(ET.Element("custom_data"))
+        return
+    new = copy.deepcopy(custom_data_src)
+    if old is None:
+        element.append(new)
+    else:
+        _replace_child(element, old, new)
+
+
+_CELL_TYPE_KEYED = (
+    ("phenotype/mechanics/cell_adhesion_affinities", "cell_adhesion_affinity",
+     DEFAULT_AFFINITY, None),
+    ("phenotype/cell_interactions/live_phagocytosis_rates", "phagocytosis_rate",
+     DEFAULT_RATE, "1/min"),
+    ("phenotype/cell_interactions/attack_rates", "attack_rate", DEFAULT_RATE, "1/min"),
+    ("phenotype/cell_interactions/fusion_rates", "fusion_rate", DEFAULT_RATE, "1/min"),
+    ("phenotype/cell_transformations/transformation_rates", "transformation_rate",
+     DEFAULT_RATE, "1/min"),
+)
+
+
+def reconcile_cell_type_references(cell_definitions_elm, cell_type_names):
+    """Square every cell definition's cross-references against the final roster.
+
+    Adding a cell type is not just its own definition: every *other* definition has a row for
+    it in each interaction matrix. Injected XML never passes through param_d, so the cell
+    types already in the model would keep matrices that do not mention the new arrivals, and
+    any stale name from the original file would survive untouched.
+
+    Each definition's own values are preserved -- they are what is read first. Only names
+    outside the roster are dropped, and only missing roster names are added, at the same
+    defaults cell_def_tab uses.
+
+    Returns [(cell_type, child_tag, dropped_name)].
+    """
+    dropped = []
+    roster = list(cell_type_names)
+    for element in cell_definitions_elm.findall("cell_definition"):
+        report = ReconcileReport(element.attrib.get("name", ""))
+        for path, tag, default, units in _CELL_TYPE_KEYED:
+            _reconcile_keyed_by_cell_type(
+                element, path, tag, roster, None, default, units, report)
+        _reconcile_asymmetric_division(element, roster, report)
+        dropped.extend((report.name, tag, name)
+                       for tag, name in report.dropped_cell_type_refs)
+    return dropped
+
+
+def reconcile_cell_def(element, substrates, existing_cd=None, cell_type_names=(),
+                       custom_data_src=None):
+    """Make one incoming <cell_definition> consistent with the model it is joining.
+
+    substrates and cell_type_names are the model's *final* rosters, after any substrate
+    BIWT referenced has been added and any new cell type accounted for.
+    """
+    report = ReconcileReport(element.attrib.get("name", ""))
+    substrates = list(substrates)
+    roster = list(cell_type_names)
+
+    if element.find("phenotype") is None:
+        return report
+
+    _reconcile_secretion(element, substrates, existing_cd, report)
+    _reconcile_chemotaxis(element, substrates, existing_cd)
+    _reconcile_sensitivities(element, substrates, existing_cd)
+
+    for path, tag, default, units in _CELL_TYPE_KEYED:
+        _reconcile_keyed_by_cell_type(
+            element, path, tag, roster, existing_cd, default, units, report)
+
+    _reconcile_asymmetric_division(element, roster, report)
+    _reconcile_custom_data(element, custom_data_src)
+
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Assembling and injecting
+# ---------------------------------------------------------------------------
+
+def assign_names_and_ids(elements_by_name, start_id=0):
+    """Write name and ID onto each cell definition. BIWT's own values are never used.
+
+    BIWT sends none, and a template library could carry one of its own; either way
+    cell_def_tab.fill_xml() drops any cell def whose ID is not its position in the sequence,
+    so the numbering has to be Studio's.
+    """
+    for offset, (name, element) in enumerate(elements_by_name.items()):
+        element.attrib["name"] = name
+        element.attrib["ID"] = str(start_id + offset)
+    return elements_by_name
+
+
+def renumber_cell_definitions(cell_definitions_elm):
+    """Force IDs to 0..N-1 in document order, after every insertion is done."""
+    for index, cell_def in enumerate(cell_definitions_elm.findall("cell_definition")):
+        cell_def.attrib["ID"] = str(index)
+
+
+def is_2d(zmin, zmax, dz):
+    """config_tab.fill_xml()'s rule: 2D when the z extent is no deeper than one voxel.
+
+    One function so the dialog's "this makes the model 3D" warning and the value actually
+    written to <use_2D> cannot disagree.
+    """
+    return (float(zmax) - float(zmin)) <= float(dz)
+
+
+def patch_domain(domain_elm, domain, deltas=None):
+    """Write BIWT's domain onto a <domain> element and recompute use_2D.
+
+    BIWT supplies no voxel sizes, so dx/dy/dz come from *deltas* -- the open model's, one per
+    axis, each left alone where None.
+    """
+    if domain_elm is None or domain is None:
+        return
+    for tag, value in (
+        ("x_min", domain.xmin), ("x_max", domain.xmax),
+        ("y_min", domain.ymin), ("y_max", domain.ymax),
+        ("z_min", domain.zmin), ("z_max", domain.zmax),
+    ):
+        xml_validate.set_text(domain_elm, tag, value)
+
+    if deltas:
+        for tag, value in zip(("dx", "dy", "dz"), deltas):
+            if value is not None:
+                xml_validate.set_text(domain_elm, tag, value)
+
+    try:
+        dz = float(xml_validate.get_text(domain_elm, "dz", "20"))
+    except (TypeError, ValueError):
+        dz = 20.0
+    xml_validate.set_text(
+        domain_elm, "use_2D", "true" if is_2d(domain.zmin, domain.zmax, dz) else "false")
+
+
+def _substrate_variable(name, index, template):
+    variable = copy.deepcopy(template)
+    variable.attrib["name"] = name
+    variable.attrib["ID"] = str(index)
+    return variable
+
+
+def build_new_document(elements_by_name, domain=None, deltas=None, extra_substrates=(),
+                       csv_folder=None, csv_file=None):
+    """A whole <PhysiCell_settings> from Studio's defaults plus BIWT's cell definitions.
+
+    Only BIWT's cell types go in -- no "default" -- so anything the user wants beyond what
+    the data described, they add in Studio.
+    """
+    root = ET.Element("PhysiCell_settings", version="devel-version")
+
+    for key in pcdefaults.SECTION_ORDER:
+        fragment = pcdefaults.XML_DEFAULT_SECTIONS[key].strip()
+        root.append(ET.fromstring("<%s>%s</%s>" % (key, fragment, key)))
+
+        if key == pcdefaults.CELL_DEFINITIONS_AFTER:
+            cell_definitions = ET.Element("cell_definitions")
+            for element in elements_by_name.values():
+                cell_definitions.append(element)
+            root.append(cell_definitions)
+
+    patch_domain(root.find("domain"), domain, deltas)
+
+    microenv = root.find("microenvironment_setup")
+    if microenv is not None and extra_substrates:
+        variables = microenv.findall("variable")
+        template = variables[0] if variables else None
+        present = {v.attrib.get("name") for v in variables}
+        index = len(variables)
+        anchor = list(microenv).index(variables[-1]) + 1 if variables else 0
+        for name in extra_substrates:
+            if name in present or template is None:
+                continue
+            microenv.insert(anchor, _substrate_variable(name, index, template))
+            anchor += 1
+            index += 1
+
+    initial = root.find("initial_conditions/cell_positions")
+    if initial is not None:
+        # The defaults arrive enabled and naming ./config/cells.csv. Left alone, a config the
+        # caller did not want pointed at a .csv would load whatever sits at that path.
+        pointing = csv_folder is not None or csv_file is not None
+        initial.attrib["enabled"] = "true" if pointing else "false"
+        if csv_folder is not None:
+            xml_validate.set_text(initial, "folder", csv_folder)
+        if csv_file is not None:
+            xml_validate.set_text(initial, "filename", csv_file)
+
+    return ET.ElementTree(root)
+
+
+def inject_cell_defs(xml_root, elements_by_name, replaced_names=()):
+    """Put the reconciled cell definitions into an existing config's <cell_definitions>.
+
+    A replaced cell type keeps its position; new ones go after the last existing one. Only
+    <cell_definition> children are added: populate_tree_cell_defs builds the XPath
+    ".//cell_definition[i+1]" from an index that counts *every* child, so anything else in
+    there shifts each subsequent lookup by one.
+    """
+    container = xml_root.find(".//cell_definitions")
+    if container is None:
+        return None
+
+    replaced_names = set(replaced_names)
+    by_name = {
+        cd.attrib.get("name"): cd
+        for cd in container.findall("cell_definition")
+    }
+
+    for name, element in elements_by_name.items():
+        # The mapping key is the authoritative name -- a template wrapped from a bare
+        # <phenotype> has no name attribute of its own, and populate_tree_cell_defs reads
+        # cell_def.attrib['name'] unguarded. Set it here so this does not depend on
+        # assign_names_and_ids having been called first.
+        element.attrib["name"] = name
+        old = by_name.get(name)
+        if name in replaced_names and old is not None:
+            _replace_child(container, old, element)
+        else:
+            container.append(element)
+
+    renumber_cell_definitions(container)
+    return container
+
+
+# ---------------------------------------------------------------------------
+# Rules
+# ---------------------------------------------------------------------------
+
+def rules_csv_path(xml_root, base_dir=None):
+    """Where the config says its ruleset lives, or None."""
+    if xml_root is None:
+        return None
+    ruleset = xml_root.find(".//cell_rules//rulesets//ruleset")
+    if ruleset is None:
+        return None
+    folder = xml_validate.get_text(ruleset, "folder", "")
+    filename = xml_validate.get_text(ruleset, "filename", "")
+    if not filename:
+        return None
+    return os.path.join(base_dir or os.getcwd(), folder or "", filename)
+
+
+def _is_rule(row):
+    """rules_tab.fill_rules()'s own test for a row being a rule and not a comment.
+
+    A rules CSV carries free-text comment lines alongside rules, and a rule the user toggled
+    off is written as a comment too -- so "starts with //" does not separate them. What does
+    is the shape: eight fields, the last of them the apply-to-dead flag.
+    """
+    return len(row) >= 8 and (row[7] or "").strip() in ("0", "1")
+
+
+def count_rules(csv_path):
+    """How many rules the ruleset holds. 0 if there is no file, or none that can be read."""
+    if not csv_path or not os.path.isfile(csv_path):
+        return 0
+    try:
+        with open(csv_path, "r") as handle:
+            return sum(1 for row in csv.reader(handle) if _is_rule(row))
+    except (OSError, csv.Error):
+        return 0
+
+
+def scan_rules_for_missing_types(csv_path, cell_type_names):
+    """Rules that name a cell type the model will not have.
+
+    A rule's first column is the cell type it applies to, and its signal and behavior can
+    each carry another one inside the string ("contact with tumor", "transform to
+    macrophage") -- so all three are checked, using the same token templates the rules tab
+    builds those strings from.
+
+    Returns [(row_number, column_label, cell_type)].
+    """
+    findings = []
+    if not csv_path or not os.path.isfile(csv_path):
+        return findings
+
+    roster = set(cell_type_names)
+    try:
+        with open(csv_path, "r") as handle:
+            for row_number, row in enumerate(csv.reader(handle), start=1):
+                if not _is_rule(row):
+                    # A comment line, not a rule. Its first field is prose, and reporting it
+                    # as a cell type the model is missing is how a ruleset's own header ends
+                    # up in a warning.
+                    continue
+                subject = (row[0] or "").strip()
+                if subject.startswith("//"):
+                    # rules_tab's convention for a rule that is toggled off. Still worth
+                    # reporting: the user turned it off, they did not delete it.
+                    subject = subject[2:].lstrip()
+                if subject and subject not in roster:
+                    findings.append((row_number, "cell type", subject))
+
+                for index, label in ((1, "signal"), (3, "behavior")):
+                    if len(row) <= index:
+                        continue
+                    named = rules_tokens.extract_cell_type((row[index] or "").strip())
+                    if named and named not in roster:
+                        findings.append((row_number, label, named))
+    except (OSError, csv.Error):
+        return findings
+
+    return findings

--- a/bin/biwt_bridge_ui.py
+++ b/bin/biwt_bridge_ui.py
@@ -1,0 +1,1322 @@
+"""
+biwt_bridge_ui.py - what Studio asks and does when BIWT finishes.
+
+BIWT hands back cell positions and a set of cell definitions. The positions go to a .csv;
+the cell definitions merge into the model that is open, become a new config file, or are
+dropped. This module runs that conversation and the writes that follow. The rules it applies
+are in biwt_bridge.py, which has no Qt in it.
+
+Two dialogs: one to decide, one to report. The first asks only where things should go -- what
+happens to each cell type was settled inside BIWT and is shown, not asked. Nothing is written
+until it is accepted, because _biwt_complete is a one-shot callback whose window is already
+gone: a Cancel here discards the whole walkthrough, so every warning has to arrive while
+backing out is still free.
+
+Authors:
+Dr. Daniel Bergman
+Rf. Credits.md
+"""
+
+import os
+import shutil
+from html import escape as _escape
+import xml.etree.ElementTree as ET
+from datetime import datetime
+
+from PyQt5 import QtCore
+from PyQt5.QtWidgets import (
+    QDialog, QDialogButtonBox, QVBoxLayout, QHBoxLayout, QGridLayout, QLabel,
+    QLineEdit, QPushButton, QRadioButton, QButtonGroup, QWidget,
+    QFileDialog, QMessageBox, QScrollArea, QFrame, QSpacerItem, QSizePolicy,
+)
+
+import biwt_bridge as bridge
+import physicell_xml_defaults as pcdefaults
+from studio_classes import QLabelSeparator, QCheckBox_custom
+from pretty_print_xml import pretty_print
+
+
+DEST_MERGE = "merge"
+DEST_NEW_FILE = "new_file"
+DEST_SKIP = "skip"
+
+
+
+def _timestamp():
+    return datetime.now().astimezone().strftime("%Y-%m-%d_%H-%M-%S")
+
+
+# Plain wording for DomainSpec.source, shown in the dialog in place of the raw marker.
+#
+# DEFAULT means BIWT fell back to its own bounds because the host gave it nothing usable.
+# Studio always sends a domain unless this model's own is malformed (see
+# ICs._domain_from_config_tab), so DEFAULT means the domain describes neither the model nor
+# the data -- the one case where adopting it is wrong.
+try:  # biwt may be absent or may not export DomainSource; fall back to the raw strings
+    from biwt.types import DomainSource as _DomainSource
+    _DOMAIN_SOURCE_LABELS = {
+        _DomainSource.HOST: "from Studio",
+        _DomainSource.DATA: "from data",
+        _DomainSource.USER: "user-edited",
+        _DomainSource.DEFAULT: "BIWT default",
+    }
+except Exception:
+    _DOMAIN_SOURCE_LABELS = {
+        "host": "from Studio",
+        "data": "from data",
+        "user": "user-edited",
+        "default": "BIWT default",
+    }
+
+
+def _domain_source_label(source):
+    """Plain wording for a DomainSpec.source, or the raw marker if it is unfamiliar.
+
+    BIWT's DomainSource docstring and its code disagree on which values exist, so an
+    unrecognised marker is shown as-is rather than mapped onto the nearest known label.
+    """
+    if not source:
+        return ""
+    return _DOMAIN_SOURCE_LABELS.get(source, source.replace("_", " "))
+
+
+def _csv_types_without_definitions(result, prospective_cell_types):
+    """Cell types the .csv places but the model will have no definition for.
+
+    See BiwtCompletionFlow._add_requests_for_csv_types for why these matter.
+    """
+    coordinates = getattr(result, "coordinates", None)
+    if coordinates is None:
+        return []
+    try:
+        placed = [str(name).strip() for name in coordinates["type"].unique()]
+    except (KeyError, TypeError, AttributeError):
+        return []
+    # Through classify_names() so this uses the same "is it the same name?" rule as the cell
+    # definitions do, rather than a second copy of it that could drift.
+    _matched, added = bridge.classify_names(placed, prospective_cell_types)
+    return sorted(set(name for name in added if name))
+
+
+def _rules_note(findings, subject):
+    """Warning about rules naming cell types that will not exist, or "" if there are none.
+
+    *subject* completes "refers to cell types ...", because which types survive depends on
+    where the cell definitions are going. findings come from scan_rules_for_missing_types().
+    """
+    if not findings:
+        return ""
+    shown = ", ".join(sorted({name for _row, _column, name in findings}))
+    # Rows, not findings: one rule can name a cell type in its subject and again inside its
+    # signal or behavior, and counting those separately overstates how many rules break.
+    rules = len({row for row, _column, _name in findings})
+    return ("! The rules file refers to cell types %s: %s (%d rule%s). Those rules will not "
+            "load." % (subject, shown, rules, "" if rules == 1 else "s"))
+
+
+def _new_file_rules_note(rule_count):
+    """Warning that a new config leaves this model's rules behind, or "" if it has none."""
+    if not rule_count:
+        return ""
+    return ("! The new config gets no rules - the %d in this model stay%s with it."
+            % (rule_count, "s" if rule_count == 1 else ""))
+
+
+def _biwt_version():
+    """The installed BIWT's version, for the receipt. Empty if it does not publish one."""
+    try:
+        import biwt
+        return getattr(biwt, "__version__", "") or ""
+    except Exception:
+        return ""
+
+
+def backup_config(path):
+    """Copy *path* aside before it is overwritten. Returns the backup path.
+
+    Suffixed .bak rather than .xml so backups do not turn up in Studio's own file dialogs
+    looking like models to open.
+    """
+    stamp = _timestamp()
+    candidate = "%s.%s.bak" % (path, stamp)
+    counter = 2
+    while os.path.exists(candidate):
+        candidate = "%s.%s_%d.bak" % (path, stamp, counter)
+        counter += 1
+    shutil.copy2(path, candidate)
+    return candidate
+
+
+def _is_writable(path):
+    """(ok, reason) for overwriting *path* -- checked before anything is mutated."""
+    folder = os.path.dirname(os.path.abspath(path)) or "."
+    if not os.path.isdir(folder):
+        return False, "the folder %s does not exist" % folder
+    if os.path.exists(path):
+        if not os.access(path, os.W_OK):
+            return False, "the file is read-only"
+    elif not os.access(folder, os.W_OK):
+        return False, "the folder %s is read-only" % folder
+    return True, ""
+
+
+class TypeRow:
+    """One incoming cell type and what is going to happen to it.
+
+    Nothing to decide here. Every choice that matters was made at BIWT's parameters step; this
+    reports what those choices mean for the model, and what Studio had to fill in where a
+    choice could not be honoured.
+    """
+
+    def __init__(self, request, replaces):
+        self.request = request
+        self.name = request.name
+        self.replaces = replaces   # True when the model already has a cell type by this name
+
+    def unchanged(self):
+        """True when this comes out as the definition the model already holds.
+
+        The model has the cell type, and the template chosen for it is that type's own
+        definition, so it is copied from itself.
+        """
+        return (self.replaces
+                and self.request.origin == bridge.ORIGIN_HOST
+                and self.request.template_name == self.name)
+
+    def brings_own_substrate_values(self):
+        """True when it arrives with secretion values rather than needing them set.
+
+        A definition copied out of this model carries whatever the user already set there. One
+        built from a template library, or from Studio's defaults, does not.
+        """
+        return self.request.origin == bridge.ORIGIN_HOST
+
+    def outcome(self):
+        if self.unchanged():
+            return "unchanged"
+        return "replaces this model's definition" if self.replaces else "added as a new cell type"
+
+    def note(self):
+        """Where this definition came from, and anything Studio had to supply itself."""
+        request = self.request
+        bits = []
+
+        if self.unchanged():
+            pass                    # the outcome column has said everything there is to say
+        elif request.origin == bridge.ORIGIN_HOST:
+            bits.append("copied from %s" % request.describe_template())
+        elif request.origin == bridge.ORIGIN_TEMPLATE:
+            bits.append(request.describe_template())
+        elif request.chose_template():
+            # A template was chosen and could not be used. Say which and why -- reporting this
+            # as "no template was chosen" would blame the user for Studio's fallback.
+            bits.append("%s %s, so Studio's default phenotype was used"
+                        % (request.describe_template(), request.error or "could not be used"))
+        else:
+            bits.append("Studio's default phenotype")
+
+        if request.filled:
+            bits.append("filled in: "
+                        + ", ".join(p.rpartition("/")[2] for p in request.filled))
+        return "; ".join(bits)
+
+
+class BiwtSaveDialog(QDialog):
+    """Everything the user decides, in one form. Writes nothing."""
+
+    def __init__(self, parent, context):
+        super().__init__(parent)
+        self.ctx = context
+        self.setWindowTitle("BIWT - Save Results")
+        self.setMinimumWidth(640)
+
+        outer = QVBoxLayout(self)
+        outer.addWidget(QLabel(context["headline"]))
+
+        # ---- cell positions -------------------------------------------------
+        outer.addWidget(QLabelSeparator("Cell positions (.csv)"))
+        path_row = QHBoxLayout()
+        self.path_edit = QLineEdit(context["csv_path"])
+        browse = QPushButton("Browse...")
+        browse.clicked.connect(self._browse_csv)
+        path_row.addWidget(self.path_edit, 1)
+        path_row.addWidget(browse)
+        outer.addLayout(path_row)
+
+        self.mode_widget = QWidget()
+        mode_row = QHBoxLayout(self.mode_widget)
+        mode_row.setContentsMargins(0, 0, 0, 0)
+        mode_row.addWidget(QLabel("File exists - "))
+        self.overwrite_rb = QRadioButton("Overwrite")
+        self.append_rb = QRadioButton("Append to existing")
+        self.overwrite_rb.setChecked(True)
+        mode_row.addWidget(self.overwrite_rb)
+        mode_row.addWidget(self.append_rb)
+        mode_row.addStretch()
+        outer.addWidget(self.mode_widget)
+
+        self.point_ics = QCheckBox_custom("Point this model's initial conditions at this file")
+        self.point_ics.setChecked(True)
+        self._point_ics_pref = True
+        self.point_ics.toggled.connect(self._point_ics_toggled)
+        # Offered only when there is something to save anyway. With no cell definitions the
+        # model is left exactly as it was, and pointing <cell_positions> somewhere new would
+        # be a config edit the user did not ask for.
+        self.point_ics.setVisible(bool(context["requests"]))
+        outer.addWidget(self.point_ics)
+
+        self.path_edit.textChanged.connect(self._update_mode)
+        self._update_mode()
+
+        if context["requests"]:
+            self._build_cell_def_section(outer)
+        else:
+            outer.addWidget(QLabelSeparator("Cell definitions"))
+            outer.addWidget(QLabel(
+                "BIWT did not assign phenotypes to any cell type, so there is nothing to\n"
+                "add to the model. Only the .csv will be written; the model is unchanged."))
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        outer.addWidget(buttons)
+
+    # ------------------------------------------------------------------
+    def _build_cell_def_section(self, outer):
+        ctx = self.ctx
+        outer.addWidget(QLabelSeparator("Cell definitions"))
+
+        self.merge_rb = QRadioButton("Merge into the current model")
+        self.new_file_rb = QRadioButton("Write a new config file:")
+        self.skip_rb = QRadioButton("Don't save cell definitions (keep the .csv only)")
+
+        # An explicit group rather than relying on auto-exclusivity: these three sit in
+        # different layout rows, and without the group checking one does not reliably
+        # uncheck the others -- which would leave destination() reading a stale answer.
+        self.destination_group = QButtonGroup(self)
+        for index, button in enumerate((self.merge_rb, self.new_file_rb, self.skip_rb)):
+            self.destination_group.addButton(button, index)
+
+        self.merge_rb.setChecked(True)
+        outer.addWidget(self.merge_rb)
+
+        detail = QLabel("        %s\n        Saves your current edits there first, and copies "
+                        "the original aside as <name>.xml.<timestamp>.bak" % ctx["config_path"])
+        detail.setStyleSheet("color: gray;")
+        outer.addWidget(detail)
+
+        outer.addWidget(self.new_file_rb)
+        new_row = QHBoxLayout()
+        new_row.addSpacing(20)
+        self.new_path_edit = QLineEdit(ctx["new_file_default"])
+        new_browse = QPushButton("Browse...")
+        new_browse.clicked.connect(self._browse_xml)
+        new_row.addWidget(self.new_path_edit, 1)
+        new_row.addWidget(new_browse)
+        outer.addLayout(new_row)
+        outer.addWidget(self.skip_rb)
+
+        # ---- domain ---------------------------------------------------
+        if ctx["domain_rows"]:
+            outer.addWidget(QLabelSeparator("Domain"))
+            grid = QGridLayout()
+            for r, (label, text) in enumerate(ctx["domain_rows"]):
+                grid.addWidget(QLabel(label), r, 0)
+                grid.addWidget(QLabel(text), r, 1)
+            # Keep the extents next to the labels they belong to. Without a column that
+            # takes up the slack, the value column stretches and the numbers drift off to
+            # the far side of the dialog.
+            grid.setColumnStretch(0, 0)
+            grid.setColumnStretch(1, 0)
+            grid.setColumnStretch(2, 1)
+            outer.addLayout(grid)
+            self.adopt_domain = QCheckBox_custom("Adopt BIWT's domain")
+            self._adopt_domain_pref = (
+                ctx["domain_differs"] and not ctx["dimensionality_flip"])
+            self.adopt_domain.setChecked(self._adopt_domain_pref)
+            self.adopt_domain.toggled.connect(self._adopt_domain_toggled)
+            outer.addWidget(self.adopt_domain)
+            if ctx["dimensionality_flip"]:
+                warn = QLabel("        Warning: adopting this domain makes the model %s." %
+                              ctx["dimensionality_flip"])
+                warn.setStyleSheet("color: red;")
+                outer.addWidget(warn)
+            self.domain_default_note = QLabel(
+                "        Unticked, the new file gets Studio's default domain, not this one.")
+            self.domain_default_note.setStyleSheet("color: gray;")
+            self.domain_default_note.setVisible(False)
+            outer.addWidget(self.domain_default_note)
+        else:
+            self.adopt_domain = None
+            self.domain_default_note = None
+
+        # ---- what will happen -----------------------------------------
+        self.outcome_header = QLabelSeparator("What will happen")
+        outer.addWidget(self.outcome_header)
+        area = self.outcome_area = QScrollArea()
+        area.setWidgetResizable(True)
+        area.setFrameShape(QFrame.NoFrame)
+        area.setMinimumHeight(140)
+        inner = QWidget()
+        inner_layout = QVBoxLayout(inner)
+
+        # The consequences live in their own widget so they can be swapped out wholesale.
+        # Disabling the scroll area is not enough on its own: these labels carry explicit
+        # stylesheet colours, which override the disabled palette, so the section would keep
+        # its normal appearance and merely stop responding.
+        self.outcome_body = QWidget()
+        grid = QVBoxLayout(self.outcome_body)
+        grid.setContentsMargins(0, 0, 0, 0)
+
+        # Only the cell types something happens to; unchanged types get no row at all, and
+        # the "nothing changes" line below covers the case where that is all of them.
+        changing = [row for row in ctx["rows"] if not row.unchanged()]
+        for row in changing:
+            line = QHBoxLayout()
+            name = QLabel(row.name)
+            name.setMinimumWidth(160)
+            line.addWidget(name)
+            outcome = QLabel(row.outcome())
+            outcome.setMinimumWidth(220)
+            line.addWidget(outcome)
+            note = QLabel(row.note())
+            note.setStyleSheet("color: gray;")
+            line.addWidget(note, 1)
+            grid.addLayout(line)
+
+        if ctx["rows"] and not changing:
+            nothing = QLabel("No cell definitions change - every cell type BIWT returned is "
+                             "already defined this way in the model.")
+            nothing.setWordWrap(True)
+            nothing.setStyleSheet("color: gray;")
+            grid.addWidget(nothing)
+
+        for text in ctx["notes"]:
+            label = QLabel(text)
+            label.setWordWrap(True)
+            label.setStyleSheet("color: #a05000;")
+            grid.addWidget(label)
+
+        # Merge only. A new file gets these substrates too, but as part of a microenvironment
+        # built from scratch, which self.new_file_substrates reports instead.
+        self.substrates_added = QLabel(
+            "! These substrates will be added to the model, with diffusion, decay and initial "
+            "condition all 0: %s. Set them in the Microenvironment tab."
+            % ", ".join(ctx["substrates_to_add"]))
+        self.substrates_added.setWordWrap(True)
+        self.substrates_added.setStyleSheet("color: #a05000;")
+        self.substrates_added.setVisible(False)
+        grid.addWidget(self.substrates_added)
+
+        # Cell types arriving with no secretion values. Its own label because whether there is
+        # anything to connect them to depends on the destination -- see _destination_changed.
+        self.substrate_setup_note = QLabel(
+            "No secretion or uptake values came with %s - set them in Cell Types > Secretion."
+            % ", ".join(ctx["needs_substrate_setup"]))
+        self.substrate_setup_note.setWordWrap(True)
+        self.substrate_setup_note.setStyleSheet("color: #a05000;")
+        self.substrate_setup_note.setVisible(False)
+        grid.addWidget(self.substrate_setup_note)
+
+        # Rules naming cell types that will not exist. Its own label because what it says
+        # depends on the destination -- see _destination_changed.
+        self.rules_note = QLabel()
+        self.rules_note.setWordWrap(True)
+        self.rules_note.setStyleSheet("color: #a05000;")
+        self.rules_note.setVisible(False)
+        grid.addWidget(self.rules_note)
+
+        # A new file gets its own microenvironment -- Studio's default plus whatever the
+        # incoming cell types use -- so it is not the substrate list showing in the tabs
+        # behind this dialog. Shown only for that destination, where it is the answer to
+        # "what happened to my substrates".
+        self.new_file_substrates = QLabel(
+            "The new file's substrates: %s." % ", ".join(ctx["new_file_substrates"]))
+        self.new_file_substrates.setWordWrap(True)
+        self.new_file_substrates.setStyleSheet("color: gray;")
+        self.new_file_substrates.setVisible(False)
+        grid.addWidget(self.new_file_substrates)
+
+        inner_layout.addWidget(self.outcome_body)
+
+        self.outcome_placeholder = QLabel(
+            "Nothing - only the cell positions .csv is being written.")
+        self.outcome_placeholder.setStyleSheet("color: gray;")
+        self.outcome_placeholder.setVisible(False)
+        inner_layout.addWidget(self.outcome_placeholder)
+
+        inner_layout.addStretch()
+        area.setWidget(inner)
+        outer.addWidget(area)
+
+        self.reload_after = QCheckBox_custom("Reload the model in Studio when done")
+        self.reload_after.setChecked(True)
+        # What the user last asked for, so a trip through a destination that forces the box
+        # one way or the other does not lose their answer.
+        self._reload_pref = True
+        self.reload_after.toggled.connect(self._reload_toggled)
+        outer.addWidget(self.reload_after)
+
+        for button in (self.merge_rb, self.new_file_rb, self.skip_rb):
+            button.toggled.connect(self._destination_changed)
+        self._destination_changed()
+
+    # ------------------------------------------------------------------
+    def _reload_toggled(self, checked):
+        if self.reload_after.isEnabled():   # ignore the forced settings below
+            self._reload_pref = checked
+
+    def _adopt_domain_toggled(self, checked):
+        if self.adopt_domain.isEnabled():
+            self._adopt_domain_pref = checked
+        self._destination_changed()
+
+    def _point_ics_toggled(self, checked):
+        if self.point_ics.isEnabled():
+            self._point_ics_pref = checked
+
+    def _destination_changed(self):
+        merging = self.merge_rb.isChecked()
+        saving = merging or self.new_file_rb.isChecked()
+
+        self.new_path_edit.setEnabled(self.new_file_rb.isChecked())
+
+        # Whichever config is being written is the one that gets pointed at the .csv. With no
+        # config being written there is nothing to point, so the box is cleared rather than
+        # left ticked over something that will not happen.
+        self.point_ics.setEnabled(saving)
+        self.point_ics.setChecked(self._point_ics_pref if saving else False)
+        self.point_ics.setToolTip(
+            "" if saving else
+            "Only the .csv is being written, so no config's initial conditions are changed.")
+        if self.adopt_domain is not None:
+            # The domain only ever reaches a file alongside the cell definitions, so with
+            # those dropped it is not adopted either.
+            self.adopt_domain.setEnabled(saving)
+            self.adopt_domain.setChecked(self._adopt_domain_pref if saving else False)
+            self.adopt_domain.setToolTip(
+                "" if saving else
+                "Only the .csv is being written, so this model's domain is left alone.")
+
+        # None of those consequences follow if the cell definitions are being dropped, so the
+        # list is replaced by a line saying so rather than left standing.
+        self.outcome_body.setVisible(saving)
+        self.outcome_placeholder.setVisible(not saving)
+        self.new_file_substrates.setVisible(self.new_file_rb.isChecked())
+        self.substrates_added.setVisible(bool(merging and self.ctx["substrates_to_add"]))
+        if self.domain_default_note is not None:
+            self.domain_default_note.setVisible(
+                self.new_file_rb.isChecked() and not self.adopt_domain.isChecked())
+
+        # Which substrates those cell types come out at 0 for is whichever set the file they
+        # are going into has - the open model's for a merge, and a new file's own, which is
+        # built from Studio's defaults and owes nothing to the model. With no substrates
+        # either way there is nothing to connect and nothing to say.
+        have = (self.ctx["new_file_substrates"] if self.new_file_rb.isChecked()
+                else self.ctx["model_substrates"])
+        self.substrate_setup_note.setVisible(
+            bool(saving and have and self.ctx["needs_substrate_setup"]))
+
+        # A new file gets Studio's default <cell_rules>, so this model's ruleset is left
+        # behind wholesale. A merge keeps it and only adds or replaces cell types, so a
+        # finding there means the ruleset already named something this model does not define.
+        if self.new_file_rb.isChecked():
+            text = _new_file_rules_note(self.ctx["model_rule_count"])
+        else:
+            text = _rules_note(self.ctx["rules_findings"], "this model does not have")
+        self.rules_note.setText(text)
+        self.rules_note.setVisible(bool(text))
+
+        # A merge writes cell definitions into the file behind Studio's back: param_d still
+        # holds the old ones, and the next File > Save rebuilds <cell_definitions> from it,
+        # undoing the merge. So the reload is not optional there.
+        if merging:
+            self.reload_after.setEnabled(False)
+            self.reload_after.setChecked(True)
+            self.reload_after.setToolTip(
+                "A merge always reloads - the Cell Types tab has to be rebuilt from the "
+                "merged file, or the next Save would undo the merge.")
+        elif saving:
+            self.reload_after.setEnabled(True)
+            self.reload_after.setChecked(self._reload_pref)
+            self.reload_after.setToolTip("")
+        else:
+            # Nothing is written, so there is nothing to reload -- say so by clearing it, not
+            # just grey out a tick that would never happen.
+            self.reload_after.setEnabled(False)
+            self.reload_after.setChecked(False)
+            self.reload_after.setToolTip(
+                "Nothing is being written, so there is nothing to reload.")
+
+    def _update_mode(self):
+        self.mode_widget.setVisible(os.path.exists(self.path_edit.text().strip()))
+
+    def _browse_csv(self):
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Save cells.csv", self.path_edit.text(),
+            "CSV files (*.csv);;All files (*)")
+        if path:
+            self.path_edit.setText(path)
+
+    def _browse_xml(self):
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Save PhysiCell Config", self.new_path_edit.text(),
+            "XML files (*.xml);;All files (*)")
+        if path:
+            self.new_path_edit.setText(path)
+
+    # ------------------------------------------------------------------
+    def destination(self):
+        if not self.ctx["requests"]:
+            return DEST_SKIP
+        if self.merge_rb.isChecked():
+            return DEST_MERGE
+        if self.new_file_rb.isChecked():
+            return DEST_NEW_FILE
+        return DEST_SKIP
+
+    def accept(self):
+        """Refuse a Save the flow could not act on, rather than let it close and do nothing.
+
+        Both paths are typed by hand, so both can be blank. Caught here because by the time
+        the flow reads them the .csv may already be on disk, and backing out at that point
+        would mean a file written and no word about why nothing else was.
+        """
+        missing = None
+        if not self.csv_path():
+            missing = ("a file to write the cell positions to", self.path_edit)
+        elif self.new_file_rb.isChecked() and not self.new_file_path():
+            missing = ("a path for the new config file", self.new_path_edit)
+        if missing is None:
+            return super().accept()
+
+        QMessageBox.warning(self.parent() or self, "BIWT - Save Results",
+                            "Enter %s." % missing[0])
+        missing[1].setFocus()
+
+    def csv_path(self):
+        return self.path_edit.text().strip()
+
+    def append_mode(self):
+        return self.append_rb.isChecked()
+
+    def wants_ics_pointed(self):
+        return self.point_ics.isChecked()
+
+    def new_file_path(self):
+        return self.new_path_edit.text().strip()
+
+    def wants_domain(self):
+        return self.adopt_domain is not None and self.adopt_domain.isChecked()
+
+    def wants_reload(self):
+        return self.reload_after.isChecked()
+
+
+class BiwtCompletionFlow:
+    """Drives everything between BIWT finishing and Studio showing the result."""
+
+    def __init__(self, ics_tab):
+        self.ics = ics_tab
+        self.xml_creator = ics_tab.xml_creator
+
+    # ------------------------------------------------------------------
+    def run(self, result):
+        if result is None:
+            return  # BIWT calls back with None when the user cancels.
+
+        requests = bridge.extract_cell_defs(result)
+        self._add_requests_for_csv_types(result, requests)
+        self._resolve(requests, self.xml_creator.xml_root.find(".//cell_definitions"))
+        context = self._build_context(result, requests)
+        dialog = BiwtSaveDialog(self.ics, context)
+        if dialog.exec_() != QDialog.Accepted:
+            return
+
+        csv_path = dialog.csv_path()
+        if not csv_path:
+            return
+
+        self._strip_csv_type_names(result)
+        if not self._save_csv(result, csv_path, dialog.append_mode()):
+            return
+
+        folder, filename = os.path.split(csv_path)
+        self.ics.csv_folder.setText(folder or ".")
+        self.ics.output_file.setText(filename)
+
+        destination = dialog.destination()
+        if destination == DEST_SKIP:
+            # Nothing else is touched -- with no cell definitions to add, the model the
+            # user has open is left exactly as it was.
+            self._receipt(csv_path, result, None, None, [], [], [], context)
+            return
+
+        chosen, replaced = self._chosen_cell_defs(context["rows"], merging=(destination == DEST_MERGE))
+        if not chosen:
+            self._receipt(csv_path, result, None, None, [], [], [], context)
+            return
+
+        if destination == DEST_MERGE:
+            self._merge(dialog, result, chosen, replaced, csv_path, context)
+        else:
+            self._write_new_file(dialog, result, chosen, csv_path, context)
+
+    # ------------------------------------------------------------------
+    def _strip_csv_type_names(self, result):
+        """Trim whitespace off the .csv's cell type names, as the config's are trimmed."""
+        coordinates = getattr(result, "coordinates", None)
+        if coordinates is None or "type" not in getattr(coordinates, "columns", []):
+            return
+        result.coordinates = coordinates.assign(
+            type=coordinates["type"].astype(str).str.strip())
+
+    def _add_requests_for_csv_types(self, result, requests):
+        """Add a request for every cell type the .csv places that has no definition coming.
+
+        A type left at "(none)" is simply absent from BIWT's mapping. Where the model already
+        has that type, absence is the useful answer -- keep the definition Studio holds. Where
+        it does not, the .csv would place cells that nothing defines, which PhysiCell refuses
+        and the ICs tab reports only as an opaque "Invalid cell type name".
+        """
+        try:
+            existing = list(self.xml_creator.celldef_tab.param_d.keys())
+        except AttributeError:
+            existing = []
+        known = list(requests) + existing
+        for name in _csv_types_without_definitions(result, known):
+            requests[name] = bridge.request_for_csv_type(name)
+        return requests
+
+    def _resolve(self, requests, cell_definitions_elm):
+        """Give every request an element, then fill in any phenotype section it lacks."""
+        nanohub = getattr(self.xml_creator, "nanohub_flag", False)
+        data_dir = getattr(self.xml_creator, "absolute_data_dir", None)
+        bridge.resolve_cell_defs(requests, cell_definitions_elm, nanohub, data_dir)
+        bridge.repair_cell_defs(requests, nanohub_flag=nanohub, data_dir=data_dir)
+        return requests
+
+    def _build_context(self, result, requests):
+        xml_root = self.xml_creator.xml_root
+        celldef_tab = self.xml_creator.celldef_tab
+        existing_names = list(celldef_tab.param_d.keys())
+
+        # Exact name only. Studio does no matching of its own: what the user called a cell type
+        # in BIWT is what gets built, and if they meant one of this model's types they had its
+        # own name to pick at the parameters step.
+        matched, _added = bridge.classify_names(list(requests), existing_names)
+        rows = [TypeRow(request, request.name in matched) for request in requests.values()]
+
+        model_subs = bridge.model_substrates(xml_root)
+        referenced = bridge.collect_referenced_substrates(requests)
+        to_add = [s for s in referenced if s not in model_subs]
+        # What "Write a new config file" would produce, from the same function that writes it.
+        new_file_subs, new_file_extra = bridge.new_file_substrates(requests)
+        # A cell type taken from this model names every substrate this model has, so choosing
+        # one carries the lot into a new config. Surprising enough to explain, and it needs a
+        # cell type to point at as the reason.
+        carried_substrates = [s for s in new_file_extra if s in model_subs]
+        carried_because = next((r.name for r in rows if r.request.from_host()), "")
+
+        # What happens to the rules is entirely a question of destination. A merge keeps this
+        # model's <cell_rules>, and only adds and replaces cell types, so anything the ruleset
+        # names is still there afterwards -- a finding means the ruleset was already out of
+        # step. A new file takes its <cell_rules> from Studio's defaults like every other
+        # section, so the ruleset does not come across at all and its cell types are beside
+        # the point; what matters is how much is being left behind.
+        rules_csv = bridge.rules_csv_path(xml_root)
+        merged_roster = list(existing_names) + [r.name for r in rows if r.name not in matched]
+        rules_findings = bridge.scan_rules_for_missing_types(rules_csv, merged_roster)
+        model_rule_count = bridge.count_rules(rules_csv)
+
+        # Two reasons a cell type ends up on Studio's default phenotype, reported separately
+        # because only one of them is the user's doing.
+        no_template = sorted(r.name for r in rows
+                             if not r.request.chose_template()
+                             and r.request.origin == bridge.ORIGIN_DEFAULT)
+        unusable = sorted(r.name for r in rows
+                          if r.request.chose_template()
+                          and r.request.origin == bridge.ORIGIN_DEFAULT)
+
+        notes = []
+        if unusable:
+            notes.append(
+                "! The template chosen for %s could not be used, so %s built from Studio's "
+                "generic default phenotype instead. The rows above say why."
+                % (", ".join(unusable), "it was" if len(unusable) == 1 else "they were"))
+        if no_template:
+            notes.append(
+                "! No template was chosen for: %s. The .csv places cells of these types so "
+                "they will be created with Studio's generic default phenotype."
+                % ", ".join(no_template))
+        # Only the cell types that actually arrive without secretion values. A run where every
+        # type came from this model's own definitions changes no secretion at all, and saying
+        # otherwise sends the user looking for something that is not there.
+        needs_setup = sorted(r.name for r in rows if not r.brings_own_substrate_values())
+        # Neither this nor the rules warning is in the notes list: both say something
+        # different per destination, so the dialog carries them in labels of their own.
+
+        foreign = sorted({
+            request.source for request in requests.values()
+            if request.source and not request.from_host()
+            and not bridge.is_bundled_library(request.source)})
+        if foreign:
+            notes.append(
+                "These phenotypes came from a template library other than the one Studio "
+                "ships: %s" % ", ".join(foreign))
+
+        # Both numbers off the .csv, which is what "placed" means. len(requests) is the
+        # number of cell definitions Studio will build, and the two differ whenever a type is
+        # defined but has no cells, or has cells and a definition the model already holds.
+        count, kinds = 0, 0
+        try:
+            count = len(result.coordinates)
+            kinds = len({str(n).strip() for n in result.coordinates["type"].unique()
+                         if str(n).strip()})
+        except Exception:
+            pass
+        headline = "BIWT placed %s cells in %d cell type%s." % (
+            format(count, ","), kinds, "" if kinds == 1 else "s")
+        if not count:
+            headline = "BIWT placed no cells."
+
+        config_path = os.path.abspath(self.xml_creator.current_xml_file)
+        return {
+            "headline": headline,
+            "csv_path": self._default_csv_path(),
+            "config_path": config_path,
+            "new_file_default": os.path.join(
+                os.path.dirname(config_path), "PhysiCell_settings_biwt.xml"),
+            "requests": requests,
+            "rows": rows,
+            "notes": notes,
+            "substrates_to_add": to_add,
+            "new_file_substrates": new_file_subs,
+            "model_substrates": model_subs,
+            "needs_substrate_setup": needs_setup,
+            "carried_substrates": carried_substrates,
+            "carried_because": carried_because,
+            "rules_findings": rules_findings,
+            "model_rule_count": model_rule_count,
+            "no_template": no_template,
+            "unusable_template": unusable,
+            **self._domain_context(result),
+        }
+
+    def _default_csv_path(self):
+        folder = self.ics.csv_folder.text().strip() or "config"
+        name = self.ics.output_file.text().strip() or "cells.csv"
+        return os.path.join(folder, name)
+
+    def _domain_context(self, result):
+        domain = getattr(result, "domain_used", None)
+        config_tab = self.xml_creator.config_tab
+        if domain is None:
+            return {"domain_rows": [], "domain_differs": False, "dimensionality_flip": ""}
+
+        def current(widget, fallback=0.0):
+            try:
+                return float(widget.text())
+            except (ValueError, AttributeError):
+                return fallback
+
+        now = (current(config_tab.xmin), current(config_tab.xmax),
+               current(config_tab.ymin), current(config_tab.ymax),
+               current(config_tab.zmin), current(config_tab.zmax))
+        theirs = (float(domain.xmin), float(domain.xmax),
+                  float(domain.ymin), float(domain.ymax),
+                  float(domain.zmin), float(domain.zmax))
+
+        # Pairs in the Config tab's order: x, y, z.
+        fmt = lambda d: "[%g, %g] x [%g, %g] x [%g, %g]" % d
+        label = _domain_source_label(getattr(domain, "source", ""))
+        rows = [("current:", fmt(now)),
+                ("BIWT:", fmt(theirs) + ("   (%s)" % label if label else ""))]
+
+        differs = any(abs(a - b) > 1e-9 for a, b in zip(now, theirs))
+
+        try:
+            dz = float(config_tab.zdel.text())
+        except (ValueError, AttributeError):
+            dz = 20.0
+        was_2d = bridge.is_2d(now[4], now[5], dz)
+        becomes_2d = bridge.is_2d(theirs[4], theirs[5], dz)
+        flip = ""
+        if was_2d != becomes_2d:
+            flip = "2D" if becomes_2d else "3D"
+            if flip == "3D" and not getattr(self.xml_creator, "model3D_flag", False):
+                flip = ("3D. Studio is running in 2D mode, so the ICs plot will ignore z "
+                        "and cell motility stays 2D - restart with --3D to plot in 3D")
+        return {"domain_rows": rows, "domain_differs": differs, "dimensionality_flip": flip}
+
+    # ------------------------------------------------------------------
+    def _chosen_cell_defs(self, rows, merging):
+        """{name: ExtractedCellDef}, plus the names whose definitions are being replaced."""
+        chosen = {row.name: row.request for row in rows}
+        replaced = {row.name for row in rows if merging and row.replaces}
+        return chosen, replaced
+
+    def _save_csv(self, result, out_path, append):
+        out_dir = os.path.dirname(out_path)
+        try:
+            if out_dir and not os.path.isdir(out_dir):
+                os.makedirs(out_dir, exist_ok=True)
+
+            if os.path.exists(out_path) and append:
+                import pandas as _pd
+                new_rows = result.coordinates[["x", "y", "z", "type"]]
+
+                # A Studio cells CSV starts with x,y,z,type. Let pandas parse the header
+                # (nrows=0 reads columns only) and refuse anything else rather than
+                # trying to reshape it: appending to a file whose columns are ordered
+                # differently would silently write each value into the wrong column.
+                existing_cols = list(_pd.read_csv(out_path, nrows=0).columns)
+                if existing_cols[:4] != ["x", "y", "z", "type"]:
+                    raise ValueError(
+                        "Cannot append: this file's first four columns are "
+                        "%s, but a PhysiCell cells CSV must start with "
+                        "['x', 'y', 'z', 'type']. Pick another file, or overwrite it."
+                        % (existing_cols[:4],))
+
+                if len(existing_cols) == 4:
+                    # Exactly the columns we write: append in place, no rewrite.
+                    new_rows.to_csv(out_path, mode="a", header=False, index=False)
+                else:
+                    # Extra columns after x,y,z,type (e.g. custom data). Appending only
+                    # four fields would leave a ragged row PhysiCell may not parse, so
+                    # align by name and rewrite, leaving the extras blank for new cells.
+                    existing = _pd.read_csv(out_path)
+                    _pd.concat([existing, new_rows], ignore_index=True).to_csv(out_path, index=False)
+            else:
+                result.to_csv(out_path)
+        except Exception as e:
+            # Deliberately broad: besides OSError, the append path can raise KeyError
+            # if the result lacks the x/y/z/type columns, and a malformed existing CSV
+            # raises from pandas. None of that should take the UI down mid-save.
+            QMessageBox.critical(
+                self.ics,
+                "BIWT - Could not save cells CSV",
+                "Failed to write '%s':\n\n%s: %s" % (out_path, type(e).__name__, e),
+            )
+            return False
+        return True
+
+    # ------------------------------------------------------------------
+    def _merge(self, dialog, result, chosen, replaced, csv_path, context):
+        xml_creator = self.xml_creator
+        config_path = xml_creator.current_xml_file
+
+        ok, reason = _is_writable(config_path)
+        if not ok:
+            QMessageBox.critical(
+                self.ics, "BIWT - Cannot merge",
+                "Studio cannot write to %s.\n\n%s\n\nNothing was changed. Use "
+                '"Write a new config file" instead, or fix the file\'s permissions.'
+                % (os.path.abspath(config_path), reason))
+            return
+
+        # Before anything is touched. check_valid_cell_defs() offers Cancel, and cancelling
+        # after the substrates went in would leave them in a model this says nothing about.
+        # It reads param_d for duplicate and non-contiguous IDs, so it does not care that the
+        # new substrates are not in yet.
+        if not xml_creator.celldef_tab.check_valid_cell_defs():
+            # Cancelled at the ID check, which explains itself. The .csv is already written,
+            # though, so end on the same receipt the "keep the .csv only" destination gets
+            # rather than on nothing at all.
+            self._receipt(csv_path, result, None, None, [], [], [], context)
+            return
+
+        # Add substrates first: microenv_tab fans out to celldef_tab.add_new_substrate(),
+        # which seeds secretion and chemotactic sensitivity on *every* cell def already in
+        # the model. Doing it after the flush would leave those cell defs without the new
+        # substrate, and cell_def_tab.fill_xml() raises on exactly that.
+        added_substrates = []
+        for name in context["substrates_to_add"]:
+            try:
+                xml_creator.microenv_tab.new_substrate_named(name)
+                added_substrates.append(name)
+            except Exception as e:
+                QMessageBox.critical(
+                    self.ics, "BIWT - Cannot merge",
+                    "Could not add the substrate '%s' to the model:\n\n%s: %s\n\n"
+                    "Nothing was written." % (name, type(e).__name__, e))
+                return
+
+        self._apply_widgets(dialog, result, csv_path)
+
+        if not xml_creator.update_xml_from_gui():
+            # Past the point where backing out is free: the substrates and the widget values
+            # are already in the model. Nothing is written to disk, but saying nothing would
+            # leave the user with changes they did not make and no idea where they came from.
+            QMessageBox.warning(
+                self.ics, "BIWT - Merge stopped",
+                "Studio could not update the model from the tabs, so nothing was written to "
+                "%s.\n\nThe model in front of you already has %s. Undo them by re-opening the "
+                "file without saving."
+                % (os.path.abspath(config_path),
+                   " and ".join(filter(None, [
+                       "the substrates %s" % ", ".join(added_substrates) if added_substrates else "",
+                       "the values BIWT proposed"]))))
+            return
+
+        xml_root = xml_creator.xml_root
+        # Re-copy the host-sourced ones now the flush has written the user's pending edits,
+        # then fill anything the fresh copy lacks.
+        container = xml_root.find(".//cell_definitions")
+        bridge.recopy_host_definitions(chosen, container)
+        self._resolve(chosen, container)
+
+        substrates = bridge.model_substrates(xml_root)
+        existing = {cd.attrib.get("name"): cd
+                    for cd in xml_root.findall(".//cell_definitions/cell_definition")}
+        roster = [name for name in bridge.model_cell_type_names(xml_root)]
+        for name in chosen:
+            if name not in roster:
+                roster.append(name)
+
+        custom_src = self._custom_data_source(existing)
+
+        reports = []
+        for name, request in chosen.items():
+            request.element.attrib["name"] = name
+            reports.append(bridge.reconcile_cell_def(
+                request.element, substrates, existing.get(name), roster, custom_src))
+
+        try:
+            backup = backup_config(config_path)
+        except OSError as e:
+            QMessageBox.critical(
+                self.ics, "BIWT - Cannot merge",
+                "Could not back up %s before overwriting it:\n\n%s: %s\n\nNothing was "
+                "written." % (config_path, type(e).__name__, e))
+            return
+
+        elements = {name: request.element for name, request in chosen.items()}
+        container = bridge.inject_cell_defs(xml_root, elements, replaced)
+        if container is not None:
+            # Now that the final roster is known, give every definition -- not just the ones
+            # that arrived -- a row for each cell type in it.
+            bridge.reconcile_cell_type_references(
+                container, bridge.model_cell_type_names(xml_root))
+        if container is None:
+            QMessageBox.critical(
+                self.ics, "BIWT - Cannot merge",
+                "%s has no <cell_definitions> section, so there is nowhere to put these "
+                "cell types.\n\nNothing was written." % os.path.abspath(config_path))
+            return
+
+        try:
+            xml_creator.tree.write(config_path)
+            pretty_print(config_path, config_path)
+        except OSError as e:
+            QMessageBox.critical(
+                self.ics, "BIWT - Could not save config XML",
+                "Failed to write '%s':\n\n%s: %s\n\nYour model now holds the merged cell "
+                "types in memory but they are not saved. A backup of the original is at "
+                "%s." % (config_path, type(e).__name__, e, backup))
+            return
+
+        self._reload(config_path)
+        # A cell type copied from its own definition is still injected -- same content, same
+        # slot -- but it is not something that happened to the model, so it is not reported
+        # as one.
+        unchanged = {row.name for row in context["rows"] if row.unchanged()}
+        self._receipt(csv_path, result, config_path, backup,
+                      sorted(n for n in replaced if n not in unchanged),
+                      [n for n in chosen if n not in replaced],
+                      added_substrates, context, reports,
+                      rules_findings=context["rules_findings"])
+
+    def _write_new_file(self, dialog, result, chosen, csv_path, context):
+        path = dialog.new_file_path()
+        if not path:
+            return
+        ok, reason = _is_writable(path)
+        if not ok:
+            QMessageBox.critical(
+                self.ics, "BIWT - Cannot write config",
+                "Studio cannot write to %s.\n\n%s\n\nNothing was changed."
+                % (os.path.abspath(path), reason))
+            return
+
+        # "Use the host's definition" still means this model's, even when writing elsewhere --
+        # and it means as the user has it now, not as it was last saved. Cell Types edits live
+        # in celldef_tab.param_d until a flush writes them into the tree, so without this the
+        # copy would silently be the stale one. The flush touches only the tree in memory; the
+        # file this model came from is not written.
+        xml_creator = self.xml_creator
+        if not xml_creator.update_xml_from_gui():
+            QMessageBox.critical(
+                self.ics, "BIWT - Cannot write config",
+                "Studio could not read the current state of the model's tabs, so the cell "
+                "definitions it would copy cannot be trusted.\n\nNothing was written.")
+            return
+        container = xml_creator.xml_root.find(".//cell_definitions")
+        bridge.recopy_host_definitions(chosen, container)
+        self._resolve(chosen, container)
+
+        substrates, extra = bridge.new_file_substrates(chosen)
+        roster = list(chosen)
+
+        reports = []
+        for name, request in chosen.items():
+            request.element.attrib["name"] = name
+            reports.append(
+                bridge.reconcile_cell_def(request.element, substrates, None, roster, None))
+
+        elements = {name: request.element for name, request in chosen.items()}
+        bridge.assign_names_and_ids(elements, start_id=0)
+
+        domain = getattr(result, "domain_used", None) if dialog.wants_domain() else None
+        config_tab = self.xml_creator.config_tab
+        deltas = []
+        for widget in (config_tab.xdel, config_tab.ydel, config_tab.zdel):
+            try:
+                deltas.append(float(widget.text()))
+            except (ValueError, AttributeError):
+                deltas.append(None)
+
+        # The same checkbox the merge path honours, so it means one thing wherever it is
+        # ticked: the config being written loads these cells at startup. Left None, the new
+        # file keeps the defaults' disabled <cell_positions>.
+        csv_folder = csv_file = None
+        if dialog.wants_ics_pointed():
+            csv_folder, csv_file = os.path.split(csv_path)
+            csv_folder = csv_folder or "./config"
+        tree = bridge.build_new_document(
+            elements, domain, deltas, extra, csv_folder, csv_file)
+
+        try:
+            tree.write(path)
+            pretty_print(path, path)
+        except OSError as e:
+            QMessageBox.critical(
+                self.ics, "BIWT - Could not save config XML",
+                "Failed to write '%s':\n\n%s: %s" % (path, type(e).__name__, e))
+            return
+
+        if dialog.wants_reload():
+            self._reload(path)
+        # The whole list, not just `extra`: every substrate in a new file is new to it, and
+        # which ones came across is the thing the user cannot see from the destination row.
+        self._receipt(csv_path, result, path, None, [], list(chosen), substrates,
+                      context, reports, new_file=True, reloaded=dialog.wants_reload())
+
+    # ------------------------------------------------------------------
+    def _apply_widgets(self, dialog, result, csv_path):
+        """Push the domain and the .csv path into the Config tab, before the flush.
+
+        config_tab.fill_xml() is what carries these into the XML, and it derives use_2D
+        from the z extent itself -- so setting the widgets and letting it run is both less
+        code and the only way the two stay consistent.
+        """
+        config_tab = self.xml_creator.config_tab
+
+        if dialog.wants_domain():
+            domain = getattr(result, "domain_used", None)
+            if domain is not None:
+                for widget, value in (
+                    (config_tab.xmin, domain.xmin), (config_tab.xmax, domain.xmax),
+                    (config_tab.ymin, domain.ymin), (config_tab.ymax, domain.ymax),
+                    (config_tab.zmin, domain.zmin), (config_tab.zmax, domain.zmax),
+                ):
+                    widget.setText(str(value))
+
+        if dialog.wants_ics_pointed():
+            # fill_xml() returns early when <initial_conditions> is missing and dereferences
+            # <cell_positions> without checking, so make sure both are there first.
+            self._ensure_initial_conditions()
+            folder, filename = os.path.split(csv_path)
+            config_tab.csv_folder.setText(folder or "./config")
+            config_tab.csv_file.setText(filename)
+            config_tab.cells_csv.setChecked(True)
+
+    def _ensure_initial_conditions(self):
+        xml_root = self.xml_creator.xml_root
+        if xml_root.find(".//initial_conditions//cell_positions") is not None:
+            return
+        initial = xml_root.find(".//initial_conditions")
+        if initial is None:
+            initial = ET.fromstring(
+                "<initial_conditions>%s</initial_conditions>"
+                % pcdefaults.XML_DEFAULT_SECTIONS["initial_conditions"].strip())
+            xml_root.append(initial)
+        elif initial.find("cell_positions") is None:
+            template = ET.fromstring(
+                "<initial_conditions>%s</initial_conditions>"
+                % pcdefaults.XML_DEFAULT_SECTIONS["initial_conditions"].strip())
+            initial.append(template.find("cell_positions"))
+
+    def _custom_data_source(self, existing):
+        """A <custom_data> to give new cell types, so the shared table stays consistent."""
+        if not existing:
+            return None
+        preferred = existing.get("default")
+        if preferred is None:
+            preferred = next(iter(existing.values()))
+        return preferred.find("custom_data")
+
+    def _reload(self, path):
+        """Point every one of Studio's ideas of "the open file" at *path*, then reload.
+
+        current_xml_file is what File > Save writes and config_file is what the reload
+        parses; set only the latter and Save overwrites the file that was open before.
+        """
+        xml_creator = self.xml_creator
+        xml_creator.current_xml_file = path
+        xml_creator.config_file = path
+        xml_creator.celldef_tab.config_path = path
+        if getattr(xml_creator, "studio_flag", False):
+            xml_creator.run_tab.config_file = path
+            xml_creator.run_tab.config_xml_name.setText(path)
+        xml_creator.show_sample_model()
+        self.ics.tab_widget.setCurrentIndex(self.ics.base_tab_id)
+        # show_sample_model() -> reset_xml_root() -> ics_tab.fill_gui() has already
+        # re-pointed the BIWT input at the reloaded model.
+
+    def _cell_type_trail(self, result):
+        """Lines describing labels BIWT dropped or merged, or [] if nothing to say."""
+        mapping = getattr(result, "cell_type_map", None)
+        if not isinstance(mapping, dict) or not mapping:
+            return []
+
+        deleted = sorted(original for original, final in mapping.items() if final is None)
+        merged = {}
+        for original, final in mapping.items():
+            if final is not None:
+                merged.setdefault(final, []).append(original)
+
+        lines = []
+        if deleted:
+            lines.append("Dropped in BIWT: %s." % ", ".join(deleted))
+        for final, originals in sorted(merged.items()):
+            if len(originals) > 1:
+                lines.append("Merged into %s: %s." % (final, ", ".join(sorted(originals))))
+        return lines
+
+    def _receipt(self, csv_path, result, config_path, backup, replaced, added,
+                 substrates, context, reports=(), new_file=False, rules_findings=(),
+                 reloaded=True):
+        # Built as rich text rather than indented plain text. A message box is narrow, and the
+        # long items here -- an absolute path, a list of fifteen cell types -- always wrap;
+        # with plain text the continuation returns to the left margin and the indentation
+        # stops meaning anything. List items keep a hanging indent when they wrap.
+        esc = _escape
+        csv_item = esc(csv_path)
+        try:
+            csv_item += " &mdash; %s cells" % format(len(result.coordinates), ",")
+        except Exception:
+            pass
+
+        html = ["<b>Wrote</b>", "<ul>", "<li>%s</li>" % csv_item]
+
+        if config_path:
+            folder, filename = os.path.split(os.path.abspath(config_path))
+            detail = []
+            if replaced:
+                detail.append("replaced: %s" % esc(", ".join(replaced)))
+            if added:
+                detail.append("added: %s" % esc(", ".join(added)))
+            # Name the sections, not just the cell types: "filled in" means Studio invented
+            # parameters, and which ones decides whether that matters.
+            for row in context["rows"]:
+                if row.request.filled:
+                    detail.append("%s: filled in %s" % (
+                        esc(row.name),
+                        esc(", ".join(p.rpartition("/")[2] for p in row.request.filled))))
+            if substrates:
+                detail.append("%s: %s" % (
+                    "substrates" if new_file else "new substrates",
+                    esc(", ".join(substrates))))
+            if not (replaced or added or substrates):
+                detail.append("no cell definitions changed")
+            if backup:
+                detail.append("backup: %s" % esc(os.path.basename(backup)))
+
+            html.append("<li>%s<br><span style='color:gray;'>in %s</span>%s</li>" % (
+                esc(filename), esc(folder),
+                ("<ul>%s</ul>" % "".join("<li>%s</li>" % d for d in detail)) if detail else ""))
+        html.append("</ul>")
+
+        if not config_path:
+            html.append("<p>The model was left unchanged.</p>")
+
+        # Which substrates, not just which cell types. A type carrying values for four of five
+        # substrates is not one whose "secretion and uptake are 0", and naming only the type
+        # sends the user through every row looking for the gap. Types that came out with the
+        # same gap share a line.
+        zeroed = {}
+        for report in reports:
+            if report.substrates_zeroed:
+                zeroed.setdefault(tuple(report.substrates_zeroed), []).append(report.name)
+        if config_path and zeroed:
+            groups = sorted((sorted(names), subs) for subs, names in zeroed.items())
+            html.append("<p><b>Next</b><br>Secretion and uptake are 0 for %s. "
+                        "Set them in Cell Types &gt; Secretion.</p>"
+                        % "; ".join("%s: %s" % (esc(", ".join(names)), esc(", ".join(subs)))
+                                    for names, subs in groups))
+
+        # Every note below describes a cell definition. When no config was written there are
+        # none, so saying any of this would contradict "the model was left unchanged".
+        notes = []
+        if config_path:
+            # A new file's microenvironment is built from Studio's defaults, so a substrate
+            # from the open model appearing in it needs explaining -- and so does why the
+            # quiet ones were not left behind.
+            if new_file and context["carried_substrates"]:
+                notes.append(
+                    "The currently loaded substrates were copied into the new config: %s. "
+                    "That is because %s was taken from this model and names them."
+                    % (esc(", ".join(context["carried_substrates"])),
+                       esc(context["carried_because"])))
+            if context["unusable_template"]:
+                notes.append(
+                    "The template chosen for %s could not be used, so Studio's generic default "
+                    "phenotype was used instead. Set %s up in Cell Types."
+                    % (esc(", ".join(context["unusable_template"])),
+                       "it" if len(context["unusable_template"]) == 1 else "them"))
+            if context["no_template"]:
+                notes.append(
+                    "%s had no template, so %s created with Studio's generic default phenotype "
+                    "rather than anything drawn from this model. Set them up in Cell Types."
+                    % (esc(", ".join(context["no_template"])),
+                       "was" if len(context["no_template"]) == 1 else "were"))
+            if new_file and context["model_rule_count"]:
+                notes.append("The new config has no rules - the %d in this model stayed with it."
+                             % context["model_rule_count"])
+            if rules_findings:
+                names = sorted({n for _r, _c, n in rules_findings})
+                notes.append("The rules file still refers to %s." % esc(", ".join(names)))
+            # cell_type_map is BIWT's audit trail from input cluster to output cell type. Only
+            # worth showing where it says something the cell type list does not: a label that
+            # was dropped, or several that were merged into one.
+            notes.extend(esc(line) for line in self._cell_type_trail(result))
+        if notes:
+            html.append("<p><b>Note</b></p><ul>%s</ul>"
+                        % "".join("<li>%s</li>" % n for n in notes))
+
+        if new_file and not reloaded and notes:
+            notes.insert(0, "Studio still has the previous model open - open %s to make any of "
+                            "the changes below." % esc(os.path.basename(config_path)))
+
+        version = _biwt_version()
+        if version:
+            html.append("<p style='color:gray;'>BIWT %s</p>" % esc(version))
+
+        box = QMessageBox(self.ics)
+        box.setIcon(QMessageBox.Information)
+        box.setWindowTitle("BIWT - Done")
+        box.setTextFormat(QtCore.Qt.RichText)
+        # The body goes in the informative text: a message box renders setText() as its
+        # heading, in bold, which is unreadable for anything this long.
+        box.setText("BIWT finished.")
+        box.setInformativeText("".join(html))
+        box.setStandardButtons(QMessageBox.Ok)
+
+        # A message box is ~400px by default, which wraps a list of cell types into a column.
+        # An invisible spacer on its grid is the supported way to widen one -- it has no
+        # sizeHint of its own to set.
+        layout = box.layout()
+        layout.addItem(QSpacerItem(620, 0, QSizePolicy.Minimum, QSizePolicy.Expanding),
+                       layout.rowCount(), 0, 1, layout.columnCount())
+        box.exec()

--- a/bin/cell_templates/cell_templates.toml
+++ b/bin/cell_templates/cell_templates.toml
@@ -1,0 +1,2799 @@
+# Built-in PhysiCell cell-type phenotype templates.
+# Each value is an XML <phenotype> string.
+# Format matches the TOML user-template format accepted by biwt.
+
+"default" = """
+
+    <phenotype>
+        <cycle code="6" name="Flow cytometry model (separated)">
+            <phase_durations units="min">
+                <duration index="0" fixed_duration="false">300.</duration>
+                <duration index="1" fixed_duration="true">480.</duration>
+                <duration index="2" fixed_duration="true">240.</duration>
+                <duration index="3" fixed_duration="true">60.</duration>
+            </phase_durations>
+        </cycle>
+        <death>
+            <model code="100" name="apoptosis">
+                <death_rate units="1/min">5.31667e-05</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">516</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+            <model code="101" name="necrosis">
+                <death_rate units="1/min">0.0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">0</duration>
+                    <duration index="1" fixed_duration="true">86400</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">1.11667e-2</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">8.33333e-4</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">5.33333e-5</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">2.16667e-3</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+        </death>
+        <volume>
+            <total units="micron^3">2494</total>
+            <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+            <nuclear units="micron^3">540</nuclear>
+            <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+            <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+            <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+            <calcified_fraction units="dimensionless">0</calcified_fraction>
+            <calcification_rate units="1/min">0</calcification_rate>
+            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+        </volume>
+        <mechanics>
+            <cell_cell_adhesion_strength units="micron/min">0.4</cell_cell_adhesion_strength>
+            <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+            <relative_maximum_adhesion_distance units="dimensionless">1.25</relative_maximum_adhesion_distance>
+            <cell_adhesion_affinities />
+            <options>
+                <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+            </options>
+            <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+            <attachment_rate units="1/min">0.0</attachment_rate>
+            <detachment_rate units="1/min">0.0</detachment_rate>
+            <maximum_number_of_attachments>12</maximum_number_of_attachments>
+        </mechanics>
+        <motility>
+            <speed units="micron/min">1</speed>
+            <persistence_time units="min">1</persistence_time>
+            <migration_bias units="dimensionless">.5</migration_bias>
+            <options>
+                <enabled>false</enabled>
+                <use_2D>true</use_2D>                    
+            </options>
+        </motility>
+        <secretion />
+        <cell_interactions>
+            <apoptotic_phagocytosis_rate units="1/min">0.0</apoptotic_phagocytosis_rate>
+            <necrotic_phagocytosis_rate units="1/min">0.0</necrotic_phagocytosis_rate>
+            <other_dead_phagocytosis_rate units="1/min">0.0</other_dead_phagocytosis_rate>
+            <live_phagocytosis_rates>
+                <phagocytosis_rate name="default" units="1/min">0</phagocytosis_rate>
+            </live_phagocytosis_rates>
+            <attack_rates>
+                <attack_rate name="default" units="1/min">0</attack_rate>
+            </attack_rates>
+            <attack_damage_rate units="1/min">1</attack_damage_rate>
+            <attack_duration units="min">0.1</attack_duration>
+            <fusion_rates>
+                <fusion_rate name="default" units="1/min">0</fusion_rate>
+            </fusion_rates>
+        </cell_interactions>
+        <cell_transformations>
+            <transformation_rates>
+                <transformation_rate name="default" units="1/min">0</transformation_rate>
+            </transformation_rates>
+        </cell_transformations>
+        <cell_integrity>
+            <damage_rate units="1/min">0.0</damage_rate>
+            <damage_repair_rate units="1/min">0.0</damage_repair_rate>
+        </cell_integrity>
+    </phenotype>
+"""
+
+"Normal Epithelial" = """
+
+    <phenotype>
+        <cycle code="5" name="live">
+            <phase_transition_rates units="1/min">
+                <rate start_index="0" end_index="0" fixed_duration="false">0</rate>
+            </phase_transition_rates>
+        </cycle>
+        <death>
+            <model code="100" name="apoptosis">
+                <death_rate units="1/min">5.31667e-05</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">516</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+            <model code="101" name="necrosis">
+                <death_rate units="1/min">0.0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">0</duration>
+                    <duration index="1" fixed_duration="true">86400</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">1.11667e-2</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">8.33333e-4</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">5.33333e-5</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">2.16667e-3</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+        </death>
+        <volume>
+            <total units="micron^3">2494</total>
+            <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+            <nuclear units="micron^3">540</nuclear>
+            <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+            <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+            <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+            <calcified_fraction units="dimensionless">0</calcified_fraction>
+            <calcification_rate units="1/min">0</calcification_rate>
+            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+        </volume>
+        <mechanics>
+            <cell_cell_adhesion_strength units="micron/min">0.4</cell_cell_adhesion_strength>
+            <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+            <relative_maximum_adhesion_distance units="dimensionless">1.25</relative_maximum_adhesion_distance>
+            <cell_adhesion_affinities />
+            <options>
+                <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+            </options>
+            <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+            <attachment_rate units="1/min">0.0</attachment_rate>
+            <detachment_rate units="1/min">0.0</detachment_rate>
+        </mechanics>
+        <motility>
+            <speed units="micron/min">0</speed>
+            <persistence_time units="min">1</persistence_time>
+            <migration_bias units="dimensionless">.5</migration_bias>
+            <options>
+                <enabled>false</enabled>
+                <use_2D>true</use_2D>
+            </options>
+        </motility>
+        <secretion />
+        <cell_interactions>
+            <apoptotic_phagocytosis_rate units="1/min">0</apoptotic_phagocytosis_rate>
+            <necrotic_phagocytosis_rate units="1/min">0</necrotic_phagocytosis_rate>
+            <other_dead_phagocytosis_rate units="1/min">0</other_dead_phagocytosis_rate>
+            <live_phagocytosis_rates />
+            <attack_rates />
+            <attack_damage_rate units="1/min">1</attack_damage_rate>
+            <fusion_rates />
+        </cell_interactions>
+        <cell_transformations>
+            <transformation_rates />
+        </cell_transformations>
+    </phenotype>
+"""
+
+"Normal Mesenchymal" = """
+
+    <phenotype>
+        <cycle code="5" name="live">
+            <phase_transition_rates units="1/min">
+                <rate start_index="0" end_index="0" fixed_duration="false">0</rate>
+            </phase_transition_rates>
+        </cycle>
+        <death>
+            <model code="100" name="apoptosis">
+                <death_rate units="1/min">5.31667e-06</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">516</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+            <model code="101" name="necrosis">
+                <death_rate units="1/min">0.0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">0</duration>
+                    <duration index="1" fixed_duration="true">86400</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">1.11667e-2</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">8.33333e-4</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">5.33333e-5</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">2.16667e-3</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+        </death>
+        <volume>
+            <total units="micron^3">2494</total>
+            <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+            <nuclear units="micron^3">540</nuclear>
+            <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+            <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+            <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+            <calcified_fraction units="dimensionless">0</calcified_fraction>
+            <calcification_rate units="1/min">0</calcification_rate>
+            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+        </volume>
+        <mechanics>
+            <cell_cell_adhesion_strength units="micron/min">0.2</cell_cell_adhesion_strength>
+            <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+            <relative_maximum_adhesion_distance units="dimensionless">1.25</relative_maximum_adhesion_distance>
+            <cell_adhesion_affinities />                           
+            <options>
+                <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+            </options>
+            <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+            <attachment_rate units="1/min">0.0</attachment_rate>
+            <detachment_rate units="1/min">0.0</detachment_rate>
+        </mechanics>
+        <motility>
+            <speed units="micron/min">0.249908679</speed>
+            <persistence_time units="min">10</persistence_time>
+            <migration_bias units="dimensionless">.5</migration_bias>
+            <options>
+                <enabled>true</enabled>
+                <use_2D>true</use_2D>
+            </options>
+        </motility>
+        <secretion/>
+        <cell_interactions>
+            <dead_phagocytosis_rate units="1/min">0</dead_phagocytosis_rate>
+            <live_phagocytosis_rates />
+            <attack_rates />            
+            <attack_damage_rate units="1/min">1</attack_damage_rate>
+            <fusion_rates />                           
+        </cell_interactions>
+        <cell_transformations>
+            <transformation_rates />                            
+        </cell_transformations>
+    </phenotype>
+"""
+
+"Fibroblast" = """
+
+    <phenotype>
+        <cycle code="5" name="live">
+            <phase_transition_rates units="1/min">
+                <rate start_index="0" end_index="0" fixed_duration="false">0</rate>
+            </phase_transition_rates>
+        </cycle>
+        <death>
+            <model code="100" name="apoptosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">516</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+            <model code="101" name="necrosis">
+                <death_rate units="1/min">0.0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">0</duration>
+                    <duration index="1" fixed_duration="true">86400</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">1.11667e-2</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">8.33333e-4</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">5.33333e-5</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">2.16667e-3</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+        </death>
+        <volume>
+            <total units="micron^3">2494</total>
+            <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+            <nuclear units="micron^3">540</nuclear>
+            <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+            <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+            <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+            <calcified_fraction units="dimensionless">0</calcified_fraction>
+            <calcification_rate units="1/min">0</calcification_rate>
+            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+        </volume>
+        <mechanics>
+            <cell_cell_adhesion_strength units="micron/min">0.4</cell_cell_adhesion_strength>
+            <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+            <relative_maximum_adhesion_distance units="dimensionless">1.25</relative_maximum_adhesion_distance>
+            <cell_adhesion_affinities/>
+            <options>
+                <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+            </options>
+            <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+            <attachment_rate units="1/min">0.0</attachment_rate>
+            <detachment_rate units="1/min">0.0</detachment_rate>
+        </mechanics>
+        <motility>
+            <speed units="micron/min">8.03971290256818e-06</speed>
+            <persistence_time units="min">10</persistence_time>
+            <migration_bias units="dimensionless">.5</migration_bias>
+            <options>
+                <enabled>true</enabled>
+                <use_2D>true</use_2D>
+            </options>
+        </motility>
+        <secretion />                           
+        <cell_interactions>
+            <dead_phagocytosis_rate units="1/min">0</dead_phagocytosis_rate>
+            <live_phagocytosis_rates />
+            <attack_rates />
+            <attack_damage_rate units="1/min">1</attack_damage_rate>
+            <fusion_rates />
+        </cell_interactions>
+        <cell_transformations>
+            <transformation_rates />
+        </cell_transformations>
+    </phenotype>
+"""
+
+"Epithelial Tumor" = """
+
+    <phenotype>
+        <cycle code="5" name="live">
+            <phase_transition_rates units="1/min">
+                <rate start_index="0" end_index="0" fixed_duration="false">1e-3</rate>
+            </phase_transition_rates>
+        </cycle>
+        <death>
+            <model code="100" name="apoptosis">
+                <death_rate units="1/min">5.31667e-05</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">516</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+            <model code="101" name="necrosis">
+                <death_rate units="1/min">0.0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">0</duration>
+                    <duration index="1" fixed_duration="true">86400</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">1.11667e-2</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">8.33333e-4</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">5.33333e-5</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">2.16667e-3</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+        </death>
+        <volume>
+            <total units="micron^3">2494</total>
+            <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+            <nuclear units="micron^3">540</nuclear>
+            <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+            <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+            <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+            <calcified_fraction units="dimensionless">0</calcified_fraction>
+            <calcification_rate units="1/min">0</calcification_rate>
+            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+        </volume>
+        <mechanics>
+            <cell_cell_adhesion_strength units="micron/min">0.4</cell_cell_adhesion_strength>
+            <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+            <relative_maximum_adhesion_distance units="dimensionless">1.25</relative_maximum_adhesion_distance>
+            <cell_adhesion_affinities />                    
+            <options>
+                <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+            </options>
+            <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+            <attachment_rate units="1/min">0.0</attachment_rate>
+            <detachment_rate units="1/min">0.0</detachment_rate>
+        </mechanics>
+        <motility>
+            <speed units="micron/min">0</speed>
+            <persistence_time units="min">1</persistence_time>
+            <migration_bias units="dimensionless">.5</migration_bias>
+            <options>
+                <enabled>false</enabled>
+                <use_2D>true</use_2D>
+            </options>
+        </motility>
+        <secretion />
+        <cell_interactions>
+            <dead_phagocytosis_rate units="1/min">0</dead_phagocytosis_rate>
+            <live_phagocytosis_rates />
+            <attack_rates />                        
+            <attack_damage_rate units="1/min">1</attack_damage_rate>
+            <fusion_rates />                
+        </cell_interactions>
+        <cell_transformations>
+            <transformation_rates />
+        </cell_transformations>
+    </phenotype>
+"""
+
+"Mesenchymal Tumor" = """
+
+    <phenotype>
+        <cycle code="5" name="live">
+            <phase_transition_rates units="1/min">
+                <rate start_index="0" end_index="0" fixed_duration="false">0</rate>
+            </phase_transition_rates>
+        </cycle>
+        <death>
+            <model code="100" name="apoptosis">
+                <death_rate units="1/min">5.31667e-06</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">516</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+            <model code="101" name="necrosis">
+                <death_rate units="1/min">0.0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">0</duration>
+                    <duration index="1" fixed_duration="true">86400</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">1.11667e-2</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">8.33333e-4</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">5.33333e-5</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">2.16667e-3</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+        </death>
+        <volume>
+            <total units="micron^3">2494</total>
+            <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+            <nuclear units="micron^3">540</nuclear>
+            <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+            <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+            <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+            <calcified_fraction units="dimensionless">0</calcified_fraction>
+            <calcification_rate units="1/min">0</calcification_rate>
+            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+        </volume>
+        <mechanics>
+            <cell_cell_adhesion_strength units="micron/min">0.2</cell_cell_adhesion_strength>
+            <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+            <relative_maximum_adhesion_distance units="dimensionless">1.25</relative_maximum_adhesion_distance>
+            <cell_adhesion_affinities />
+            <options>
+                <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+            </options>
+            <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+            <attachment_rate units="1/min">0.0</attachment_rate>
+            <detachment_rate units="1/min">0.0</detachment_rate>
+        </mechanics>
+        <motility>
+            <speed units="micron/min">0.249908679</speed>
+            <persistence_time units="min">10</persistence_time>
+            <migration_bias units="dimensionless">.5</migration_bias>
+            <options>
+                <enabled>true</enabled>
+                <use_2D>true</use_2D>
+            </options>
+        </motility>
+        <secretion />
+        <cell_interactions>
+            <dead_phagocytosis_rate units="1/min">0</dead_phagocytosis_rate>
+            <live_phagocytosis_rates />
+            <attack_rates />                        
+            <attack_damage_rate units="1/min">1</attack_damage_rate>
+            <fusion_rates />                
+        </cell_interactions>
+        <cell_transformations>
+            <transformation_rates />
+        </cell_transformations>
+    </phenotype>
+"""
+
+"Macrophage" = """
+
+    <phenotype>
+        <cycle code="5" name="live">
+            <phase_transition_rates units="1/min">
+                <rate start_index="0" end_index="0" fixed_duration="false">0</rate>
+            </phase_transition_rates>
+            <standard_asymmetric_division enabled="False" />
+        </cycle>
+        <death>
+            <model code="100" name="apoptosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_transition_rates units="1/min">
+                    <rate start_index="0" end_index="1" fixed_duration="false">0.001938</rate>
+                </phase_transition_rates>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+            <model code="101" name="necrosis">
+                <death_rate units="1/min">0.0</death_rate>
+                <phase_transition_rates units="1/min">
+                    <rate start_index="0" end_index="1" fixed_duration="false">9000000000.0</rate>
+                    <rate start_index="1" end_index="2" fixed_duration="true">1.15741e-05</rate>
+                </phase_transition_rates>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">1.11667e-02</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">8.33333e-4</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">5.33333e-05</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">2.16667e-4</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">7e-05</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+        </death>
+        <volume>
+            <total units="micron^3">2494</total>
+            <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+            <nuclear units="micron^3">540</nuclear>
+            <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+            <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+            <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+            <calcified_fraction units="dimensionless">0.0</calcified_fraction>
+            <calcification_rate units="1/min">0.0</calcification_rate>
+            <relative_rupture_volume units="dimensionless">2</relative_rupture_volume>
+        </volume>
+        <mechanics>
+            <cell_cell_adhesion_strength units="micron/min">0</cell_cell_adhesion_strength>
+            <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+            <relative_maximum_adhesion_distance units="dimensionless">1.25</relative_maximum_adhesion_distance>
+            <cell_adhesion_affinities />
+            <options>
+                <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+            </options>
+            <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+            <attachment_rate units="1/min">0.0</attachment_rate>
+            <detachment_rate units="1/min">0.0</detachment_rate>
+            <maximum_number_of_attachments>12</maximum_number_of_attachments>
+        </mechanics>
+        <motility>
+            <speed units="micron/min">1.0</speed>
+            <persistence_time units="min">5</persistence_time>
+            <migration_bias units="dimensionless">0.25</migration_bias>
+            <options>
+                <enabled>true</enabled>
+                <use_2D>true</use_2D>
+            </options>
+        </motility>
+        <secretion />
+        <cell_interactions>
+            <apoptotic_phagocytosis_rate units="1/min">0.1</apoptotic_phagocytosis_rate>
+            <necrotic_phagocytosis_rate units="1/min">0.017</necrotic_phagocytosis_rate>
+            <other_dead_phagocytosis_rate units="1/min">0.0</other_dead_phagocytosis_rate>
+            <live_phagocytosis_rates />
+            <attack_rates />                        
+            <attack_damage_rate units="1/min">1</attack_damage_rate>
+            <fusion_rates />                
+        </cell_interactions>
+        <cell_transformations>
+            <transformation_rates />
+        </cell_transformations>
+    </phenotype>
+"""
+
+"M0 Macrophage" = """
+
+    <phenotype>
+        <cycle code="5" name="live">
+            <phase_transition_rates units="1/min">
+                <rate start_index="0" end_index="0" fixed_duration="false">7.2e-5</rate>
+            </phase_transition_rates>
+        </cycle>
+        <death>
+            <model code="100" name="apoptosis">
+                <death_rate units="1/min">7.2e-5</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">516</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+            <model code="101" name="necrosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">0</duration>
+                    <duration index="1" fixed_duration="true">86400</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+        </death>
+        <volume>
+            <total units="micron^3">2494</total>
+            <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+            <nuclear units="micron^3">540</nuclear>
+            <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+            <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+            <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+            <calcified_fraction units="dimensionless">0</calcified_fraction>
+            <calcification_rate units="1/min">0</calcification_rate>
+            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+        </volume>
+        <mechanics>
+            <cell_cell_adhesion_strength units="micron/min">0</cell_cell_adhesion_strength>
+            <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+            <relative_maximum_adhesion_distance units="dimensionless">1.5</relative_maximum_adhesion_distance>
+            <cell_adhesion_affinities>
+                <cell_adhesion_affinity name="tumor">1.0</cell_adhesion_affinity>
+                <cell_adhesion_affinity name="M0 macrophage">1.0</cell_adhesion_affinity>
+                <cell_adhesion_affinity name="M1 macrophage">1.0</cell_adhesion_affinity>
+                <cell_adhesion_affinity name="M2 macrophage">1.0</cell_adhesion_affinity>
+                <cell_adhesion_affinity name="Th2 CD4 T cell">1.0</cell_adhesion_affinity>
+            </cell_adhesion_affinities>
+            <options>
+                <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+            </options>
+            <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+            <attachment_rate units="1/min">0</attachment_rate>
+            <detachment_rate units="1/min">0.0</detachment_rate>
+            <maximum_number_of_attachments>12</maximum_number_of_attachments>
+        </mechanics>
+        <motility>
+            <speed units="micron/min">0.5</speed>
+            <persistence_time units="min">5</persistence_time>
+            <migration_bias units="dimensionless">0.25</migration_bias>
+            <options>
+                <enabled>true</enabled>
+                <use_2D>true</use_2D>
+            </options>
+        </motility>
+        <secretion />
+        <cell_interactions>
+            <apoptotic_phagocytosis_rate units="1/min">0.001</apoptotic_phagocytosis_rate>
+            <necrotic_phagocytosis_rate units="1/min">0.001</necrotic_phagocytosis_rate>
+            <other_dead_phagocytosis_rate units="1/min">0.001</other_dead_phagocytosis_rate>
+            <live_phagocytosis_rates />                      
+            <attack_rates />                       
+            <attack_damage_rate units="1/min">1</attack_damage_rate>
+            <attack_duration units="min">0.1</attack_duration>
+            <fusion_rates />                    
+        </cell_interactions>
+        <cell_transformations>
+            <transformation_rates />                      
+        </cell_transformations>
+        <cell_integrity>
+            <damage_rate units="1/min">0.0</damage_rate>
+            <damage_repair_rate units="1/min">0.0</damage_repair_rate>
+        </cell_integrity>
+    </phenotype>
+"""
+
+"M1 Macrophage" = """
+
+    <phenotype>
+        <cycle code="5" name="live">
+            <phase_transition_rates units="1/min">
+                <rate start_index="0" end_index="0" fixed_duration="false">7.2e-5</rate>
+            </phase_transition_rates>
+        </cycle>
+        <death>
+            <model code="100" name="apoptosis">
+                <death_rate units="1/min">7.2e-5</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">516</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+            <model code="101" name="necrosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">0</duration>
+                    <duration index="1" fixed_duration="true">86400</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+        </death>
+        <volume>
+            <total units="micron^3">2494</total>
+            <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+            <nuclear units="micron^3">540</nuclear>
+            <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+            <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+            <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+            <calcified_fraction units="dimensionless">0</calcified_fraction>
+            <calcification_rate units="1/min">0</calcification_rate>
+            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+        </volume>
+        <mechanics>
+            <cell_cell_adhesion_strength units="micron/min">0</cell_cell_adhesion_strength>
+            <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+            <relative_maximum_adhesion_distance units="dimensionless">1.5</relative_maximum_adhesion_distance>
+            <cell_adhesion_affinities />                      
+            <options>
+                <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+            </options>
+            <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+            <attachment_rate units="1/min">0</attachment_rate>
+            <detachment_rate units="1/min">0.0</detachment_rate>
+            <maximum_number_of_attachments>12</maximum_number_of_attachments>
+        </mechanics>
+        <motility>
+            <speed units="micron/min">0.5</speed>
+            <persistence_time units="min">5</persistence_time>
+            <migration_bias units="dimensionless">0.25</migration_bias>
+            <options>
+                <enabled>true</enabled>
+                <use_2D>true</use_2D>
+            </options>
+        </motility>
+        <secretion />
+        <cell_interactions>
+            <apoptotic_phagocytosis_rate units="1/min">0.001</apoptotic_phagocytosis_rate>
+            <necrotic_phagocytosis_rate units="1/min">0.001</necrotic_phagocytosis_rate>
+            <other_dead_phagocytosis_rate units="1/min">0.001</other_dead_phagocytosis_rate>
+            <live_phagocytosis_rates />                      
+            <attack_rates />                      
+            <attack_damage_rate units="1/min">1</attack_damage_rate>
+            <attack_duration units="min">0.1</attack_duration>
+            <fusion_rates />
+        </cell_interactions>
+        <cell_transformations>
+            <transformation_rates />
+        </cell_transformations>
+        <cell_integrity>
+            <damage_rate units="1/min">0.0</damage_rate>
+            <damage_repair_rate units="1/min">0.0</damage_repair_rate>
+        </cell_integrity>
+    </phenotype>
+"""
+
+"M2 Macrophage" = """
+
+    <phenotype>
+        <cycle code="5" name="live">
+            <phase_transition_rates units="1/min">
+                <rate start_index="0" end_index="0" fixed_duration="false">7.2e-5</rate>
+            </phase_transition_rates>
+        </cycle>
+        <death>
+            <model code="100" name="apoptosis">
+                <death_rate units="1/min">7.2e-5</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">516</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+            <model code="101" name="necrosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">0</duration>
+                    <duration index="1" fixed_duration="true">86400</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+        </death>
+        <volume>
+            <total units="micron^3">2494</total>
+            <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+            <nuclear units="micron^3">540</nuclear>
+            <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+            <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+            <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+            <calcified_fraction units="dimensionless">0</calcified_fraction>
+            <calcification_rate units="1/min">0</calcification_rate>
+            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+        </volume>
+        <mechanics>
+            <cell_cell_adhesion_strength units="micron/min">0</cell_cell_adhesion_strength>
+            <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+            <relative_maximum_adhesion_distance units="dimensionless">1.5</relative_maximum_adhesion_distance>
+            <cell_adhesion_affinities />       
+            <options>
+                <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+            </options>
+            <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+            <attachment_rate units="1/min">0</attachment_rate>
+            <detachment_rate units="1/min">0.0</detachment_rate>
+            <maximum_number_of_attachments>12</maximum_number_of_attachments>
+        </mechanics>
+        <motility>
+            <speed units="micron/min">0.5</speed>
+            <persistence_time units="min">5</persistence_time>
+            <migration_bias units="dimensionless">0.25</migration_bias>
+            <options>
+                <enabled>true</enabled>
+                <use_2D>true</use_2D>
+            </options>
+        </motility>
+        <secretion />
+        <cell_interactions>
+            <apoptotic_phagocytosis_rate units="1/min">0.001</apoptotic_phagocytosis_rate>
+            <necrotic_phagocytosis_rate units="1/min">0.001</necrotic_phagocytosis_rate>
+            <other_dead_phagocytosis_rate units="1/min">0.001</other_dead_phagocytosis_rate>
+            <live_phagocytosis_rates />                       
+            <attack_rates />                        
+            <attack_damage_rate units="1/min">1</attack_damage_rate>
+            <attack_duration units="min">0.1</attack_duration>
+            <fusion_rates />                       
+        </cell_interactions>
+        <cell_transformations>
+            <transformation_rates />                      
+        </cell_transformations>
+        <cell_integrity>
+            <damage_rate units="1/min">0.0</damage_rate>
+            <damage_repair_rate units="1/min">0.0</damage_repair_rate>
+        </cell_integrity>
+    </phenotype>
+"""
+
+"TH2 CD4 T Cell" = """
+
+    <phenotype>
+        <cycle code="5" name="live">
+            <phase_transition_rates units="1/min">
+                <rate start_index="0" end_index="0" fixed_duration="false">0</rate>
+            </phase_transition_rates>
+        </cycle>
+        <death>
+            <model code="100" name="apoptosis">
+                <death_rate units="1/min">7.2e-5</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">516</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+            <model code="101" name="necrosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">0</duration>
+                    <duration index="1" fixed_duration="true">86400</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+        </death>
+        <volume>
+            <total units="micron^3">2494</total>
+            <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+            <nuclear units="micron^3">540</nuclear>
+            <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+            <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+            <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+            <calcified_fraction units="dimensionless">0</calcified_fraction>
+            <calcification_rate units="1/min">0</calcification_rate>
+            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+        </volume>
+        <mechanics>
+            <cell_cell_adhesion_strength units="micron/min">0</cell_cell_adhesion_strength>
+            <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+            <relative_maximum_adhesion_distance units="dimensionless">1.5</relative_maximum_adhesion_distance>
+            <cell_adhesion_affinities />                      
+            <options>
+                <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+            </options>
+            <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+            <attachment_rate units="1/min">0</attachment_rate>
+            <detachment_rate units="1/min">0.0</detachment_rate>
+            <maximum_number_of_attachments>12</maximum_number_of_attachments>
+        </mechanics>
+        <motility>
+            <speed units="micron/min">0.5</speed>
+            <persistence_time units="min">5</persistence_time>
+            <migration_bias units="dimensionless">0.5</migration_bias>
+            <options>
+                <enabled>true</enabled>
+                <use_2D>true</use_2D>
+            </options>
+        </motility>
+        <secretion />                  
+        <cell_interactions>
+            <apoptotic_phagocytosis_rate units="1/min">0.0</apoptotic_phagocytosis_rate>
+            <necrotic_phagocytosis_rate units="1/min">0.0</necrotic_phagocytosis_rate>
+            <other_dead_phagocytosis_rate units="1/min">0.0</other_dead_phagocytosis_rate>
+            <live_phagocytosis_rates />                     
+            <attack_rates />                      
+            <attack_damage_rate units="1/min">1</attack_damage_rate>
+            <attack_duration units="min">0.1</attack_duration>
+            <fusion_rates />                      
+        </cell_interactions>
+        <cell_transformations>
+            <transformation_rates />                      
+        </cell_transformations>
+        <cell_integrity>
+            <damage_rate units="1/min">0.0</damage_rate>
+            <damage_repair_rate units="1/min">0.0</damage_repair_rate>
+        </cell_integrity>
+    </phenotype>
+"""
+
+"Other Tissue" = """
+
+    <phenotype>
+        <cycle code="5" name="live">
+            <phase_transition_rates units="1/min">
+                <rate start_index="0" end_index="0" fixed_duration="false">0</rate>
+            </phase_transition_rates>
+        </cycle>
+        <death>
+            <model code="100" name="apoptosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">516</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+            <model code="101" name="necrosis">
+                <death_rate units="1/min">0.0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">0</duration>
+                    <duration index="1" fixed_duration="true">86400</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">1.11667e-2</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">8.33333e-4</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">5.33333e-5</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">2.16667e-3</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+        </death>
+        <volume>
+            <total units="micron^3">2494</total>
+            <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+            <nuclear units="micron^3">540</nuclear>
+            <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+            <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+            <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+            <calcified_fraction units="dimensionless">0</calcified_fraction>
+            <calcification_rate units="1/min">0</calcification_rate>
+            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+        </volume>
+        <mechanics>
+            <cell_cell_adhesion_strength units="micron/min">0.4</cell_cell_adhesion_strength>
+            <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+            <relative_maximum_adhesion_distance units="dimensionless">1.25</relative_maximum_adhesion_distance>
+            <cell_adhesion_affinities />
+            <options>
+                <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+            </options>
+            <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+            <attachment_rate units="1/min">0.0</attachment_rate>
+            <detachment_rate units="1/min">0.0</detachment_rate>
+        </mechanics>
+        <motility>
+            <speed units="micron/min">0</speed>
+            <persistence_time units="min">1</persistence_time>
+            <migration_bias units="dimensionless">.5</migration_bias>
+            <options>
+                <enabled>false</enabled>
+                <use_2D>true</use_2D>
+            </options>
+        </motility>
+        <secretion />
+        <cell_interactions>
+            <apoptotic_phagocytosis_rate units="1/min">0</apoptotic_phagocytosis_rate>
+            <necrotic_phagocytosis_rate units="1/min">0</necrotic_phagocytosis_rate>
+            <live_phagocytosis_rates />
+            <attack_rates />
+            <attack_damage_rate units="1/min">1</attack_damage_rate>
+            <fusion_rates />
+        </cell_interactions>
+        <cell_transformations>
+            <transformation_rates />
+        </cell_transformations>
+    </phenotype>
+"""
+
+"Motile Tumor" = """
+
+    <phenotype>
+        <cycle code="5" name="live">
+            <phase_transition_rates units="1/min">
+                <rate start_index="0" end_index="0" fixed_duration="false">0.00072</rate>
+            </phase_transition_rates>
+            <standard_asymmetric_division enabled="False" />
+        </cycle>
+        <death>
+            <model code="100" name="apoptosis">
+                <death_rate units="1/min">5.31667e-05</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">516</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+            <model code="101" name="necrosis">
+                <death_rate units="1/min">2.8e-3</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">0</duration>
+                    <duration index="1" fixed_duration="true">86400</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+        </death>
+        <volume>
+            <total units="micron^3">2494</total>
+            <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+            <nuclear units="micron^3">540</nuclear>
+            <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+            <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+            <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+            <calcified_fraction units="dimensionless">0</calcified_fraction>
+            <calcification_rate units="1/min">0</calcification_rate>
+            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+        </volume>
+        <mechanics>
+            <cell_cell_adhesion_strength units="micron/min">0.4</cell_cell_adhesion_strength>
+            <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+            <relative_maximum_adhesion_distance units="dimensionless">1.25</relative_maximum_adhesion_distance>
+            <cell_adhesion_affinities />
+            <options>
+                <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+            </options>
+            <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+            <attachment_rate units="1/min">0.0</attachment_rate>
+            <detachment_rate units="1/min">0.0</detachment_rate>
+            <maximum_number_of_attachments>12</maximum_number_of_attachments>
+        </mechanics>
+        <motility>
+            <speed units="micron/min">0.47</speed>
+            <persistence_time units="min">15</persistence_time>
+            <migration_bias units="dimensionless">0.18</migration_bias>
+            <options>
+                <enabled>true</enabled>
+                <use_2D>true</use_2D>
+            </options>
+        </motility>
+        <secretion />
+        <cell_interactions>
+            <apoptotic_phagocytosis_rate units="1/min">0.0</apoptotic_phagocytosis_rate>
+            <necrotic_phagocytosis_rate units="1/min">0.0</necrotic_phagocytosis_rate>
+            <other_dead_phagocytosis_rate units="1/min">0.0</other_dead_phagocytosis_rate>
+            <live_phagocytosis_rates>
+                <phagocytosis_rate name="default" units="1/min">0</phagocytosis_rate>
+            </live_phagocytosis_rates>
+            <attack_rates>
+                <attack_rate name="default" units="1/min">0</attack_rate>
+            </attack_rates>
+            <attack_damage_rate units="1/min">1</attack_damage_rate>
+            <attack_duration units="min">0.1</attack_duration>
+            <fusion_rates>
+                <fusion_rate name="default" units="1/min">0</fusion_rate>
+            </fusion_rates>
+        </cell_interactions>
+        <cell_transformations>
+            <transformation_rates>
+                <transformation_rate name="default" units="1/min">0</transformation_rate>
+            </transformation_rates>
+        </cell_transformations>
+        <cell_integrity>
+            <damage_rate units="1/min">0.0</damage_rate>
+            <damage_repair_rate units="1/min">0.0</damage_repair_rate>
+        </cell_integrity>
+    </phenotype>
+"""
+
+"Tumor" = """
+
+    <phenotype>
+        <cycle code="5" name="live">
+            <phase_transition_rates units="1/min">
+                <rate start_index="0" end_index="0" fixed_duration="false">0.00072</rate>
+            </phase_transition_rates>
+            <standard_asymmetric_division enabled="False" />
+        </cycle>
+        <death>
+            <model code="100" name="apoptosis">
+                <death_rate units="1/min">5.31667e-05</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">516</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+            <model code="101" name="necrosis">
+                <death_rate units="1/min">2.8e-3</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">0</duration>
+                    <duration index="1" fixed_duration="true">86400</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+        </death>
+        <volume>
+            <total units="micron^3">2494</total>
+            <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+            <nuclear units="micron^3">540</nuclear>
+            <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+            <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+            <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+            <calcified_fraction units="dimensionless">0</calcified_fraction>
+            <calcification_rate units="1/min">0</calcification_rate>
+            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+        </volume>
+        <mechanics>
+            <cell_cell_adhesion_strength units="micron/min">0.4</cell_cell_adhesion_strength>
+            <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+            <relative_maximum_adhesion_distance units="dimensionless">1.25</relative_maximum_adhesion_distance>
+            <cell_adhesion_affinities />
+            <options>
+                <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+            </options>
+            <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+            <attachment_rate units="1/min">0.0</attachment_rate>
+            <detachment_rate units="1/min">0.0</detachment_rate>
+            <maximum_number_of_attachments>12</maximum_number_of_attachments>
+        </mechanics>
+        <motility>
+            <speed units="micron/min">0.0</speed>
+            <persistence_time units="min">0</persistence_time>
+            <migration_bias units="dimensionless">0.0</migration_bias>
+            <options>
+                <enabled>false</enabled>
+                <use_2D>true</use_2D>
+                <advanced_chemotaxis>
+                    <enabled>false</enabled>
+                    <normalize_each_gradient>false</normalize_each_gradient>
+                    <chemotactic_sensitivities />
+                </advanced_chemotaxis>
+            </options>
+        </motility>
+        <secretion />
+        <cell_interactions>
+            <apoptotic_phagocytosis_rate units="1/min">0.0</apoptotic_phagocytosis_rate>
+            <necrotic_phagocytosis_rate units="1/min">0.0</necrotic_phagocytosis_rate>
+            <other_dead_phagocytosis_rate units="1/min">0.0</other_dead_phagocytosis_rate>
+            <live_phagocytosis_rates>
+                <phagocytosis_rate name="default" units="1/min">0</phagocytosis_rate>
+            </live_phagocytosis_rates>
+            <attack_rates>
+                <attack_rate name="default" units="1/min">0</attack_rate>
+            </attack_rates>
+            <attack_damage_rate units="1/min">1</attack_damage_rate>
+            <attack_duration units="min">0.1</attack_duration>
+            <fusion_rates>
+                <fusion_rate name="default" units="1/min">0</fusion_rate>
+            </fusion_rates>
+        </cell_interactions>
+        <cell_transformations>
+            <transformation_rates>
+                <transformation_rate name="default" units="1/min">0</transformation_rate>
+            </transformation_rates>
+        </cell_transformations>
+        <cell_integrity>
+            <damage_rate units="1/min">0.0</damage_rate>
+            <damage_repair_rate units="1/min">0.0</damage_repair_rate>
+        </cell_integrity>
+    </phenotype>
+"""
+
+"Apical" = """
+
+    <phenotype>
+        <cycle code="5" name="live">
+            <phase_transition_rates units="1/min">
+                <rate start_index="0" end_index="0" fixed_duration="false">0</rate>
+            </phase_transition_rates>
+            <standard_asymmetric_division enabled="False" />
+        </cycle>
+        <death>
+            <model code="100" name="apoptosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">516</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+            <model code="101" name="necrosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">0</duration>
+                    <duration index="1" fixed_duration="true">86400</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">1.11667e-2</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">8.33333e-4</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">5.33333e-5</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">2.16667e-3</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+        </death>
+        <volume>
+            <total units="micron^3">2494</total>
+            <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+            <nuclear units="micron^3">540</nuclear>
+            <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+            <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+            <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+            <calcified_fraction units="dimensionless">0</calcified_fraction>
+            <calcification_rate units="1/min">0</calcification_rate>
+            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+        </volume>
+        <mechanics>
+            <cell_cell_adhesion_strength units="micron/min">0.4</cell_cell_adhesion_strength>
+            <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+            <relative_maximum_adhesion_distance units="dimensionless">1.25</relative_maximum_adhesion_distance>
+            <cell_adhesion_affinities>
+                <cell_adhesion_affinity name="apical">1.0</cell_adhesion_affinity>
+                <cell_adhesion_affinity name="pial">1.0</cell_adhesion_affinity>
+                <cell_adhesion_affinity name="rgc">1.0</cell_adhesion_affinity>
+                <cell_adhesion_affinity name="layer_6">1.0</cell_adhesion_affinity>
+                <cell_adhesion_affinity name="layer_5">1.0</cell_adhesion_affinity>
+                <cell_adhesion_affinity name="layer_4">1.0</cell_adhesion_affinity>
+                <cell_adhesion_affinity name="layer_3">1.0</cell_adhesion_affinity>
+                <cell_adhesion_affinity name="layer_2">1.0</cell_adhesion_affinity>
+            </cell_adhesion_affinities>
+            <options>
+                <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+            </options>
+            <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+            <attachment_rate units="1/min">0.0</attachment_rate>
+            <detachment_rate units="1/min">0.0</detachment_rate>
+            <maximum_number_of_attachments>12</maximum_number_of_attachments>
+        </mechanics>
+        <motility>
+            <speed units="micron/min">1</speed>
+            <persistence_time units="min">5</persistence_time>
+            <migration_bias units="dimensionless">.5</migration_bias>
+            <options>
+                <enabled>false</enabled>
+                <use_2D>true</use_2D>
+            </options>
+        </motility>
+        <secretion />
+        <cell_interactions>
+            <apoptotic_phagocytosis_rate units="1/min">0</apoptotic_phagocytosis_rate>
+            <necrotic_phagocytosis_rate units="1/min">0</necrotic_phagocytosis_rate>
+            <other_dead_phagocytosis_rate units="1/min">0</other_dead_phagocytosis_rate>
+            <live_phagocytosis_rates />
+            <attack_rates />
+            <attack_damage_rate units="1/min">1</attack_damage_rate>
+            <fusion_rates />
+        </cell_interactions>
+        <cell_transformations>
+            <transformation_rates />
+        </cell_transformations>
+    </phenotype>
+"""
+
+"Pial" = """
+
+    <phenotype>
+        <cycle code="5" name="live">
+            <phase_transition_rates units="1/min">
+                <rate start_index="0" end_index="0" fixed_duration="false">0</rate>
+            </phase_transition_rates>
+            <standard_asymmetric_division enabled="False" />
+        </cycle>
+        <death>
+            <model code="100" name="apoptosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">516</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+            <model code="101" name="necrosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">0</duration>
+                    <duration index="1" fixed_duration="true">86400</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">1.11667e-2</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">8.33333e-4</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">5.33333e-5</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">2.16667e-3</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+        </death>
+        <volume>
+            <total units="micron^3">499</total>
+            <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+            <nuclear units="micron^3">108</nuclear>
+            <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+            <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+            <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+            <calcified_fraction units="dimensionless">0</calcified_fraction>
+            <calcification_rate units="1/min">0</calcification_rate>
+            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+        </volume>
+        <mechanics>
+            <cell_cell_adhesion_strength units="micron/min">1</cell_cell_adhesion_strength>
+            <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+            <relative_maximum_adhesion_distance units="dimensionless">1.25</relative_maximum_adhesion_distance>
+            <cell_adhesion_affinities />
+            <options>
+                <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+            </options>
+            <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+            <attachment_rate units="1/min">0.1</attachment_rate>
+            <detachment_rate units="1/min">0.0</detachment_rate>
+            <maximum_number_of_attachments>12</maximum_number_of_attachments>
+        </mechanics>
+        <motility>
+            <speed units="micron/min">0.0</speed>
+            <persistence_time units="min">5</persistence_time>
+            <migration_bias units="dimensionless">1</migration_bias>
+            <options>
+                <enabled>true</enabled>
+                <use_2D>true</use_2D>
+                <advanced_chemotaxis>
+                    <enabled>false</enabled>
+                    <normalize_each_gradient>false</normalize_each_gradient>
+                    <chemotactic_sensitivities />
+                </advanced_chemotaxis>
+            </options>
+        </motility>
+        <secretion />
+        <cell_interactions>
+            <apoptotic_phagocytosis_rate units="1/min">0</apoptotic_phagocytosis_rate>
+            <necrotic_phagocytosis_rate units="1/min">0</necrotic_phagocytosis_rate>
+            <other_dead_phagocytosis_rate units="1/min">0</other_dead_phagocytosis_rate>
+            <live_phagocytosis_rates />
+            <attack_rates />
+            <attack_damage_rate units="1/min">1</attack_damage_rate>
+            <fusion_rates />
+        </cell_interactions>
+        <cell_transformations>
+            <transformation_rates />
+        </cell_transformations>
+    </phenotype>
+"""
+
+"RGC" = """
+
+    <phenotype>
+        <cycle code="5" name="live">
+            <phase_transition_rates units="1/min">
+                <rate start_index="0" end_index="0" fixed_duration="true">0.0013</rate>
+            </phase_transition_rates>
+            <standard_asymmetric_division enabled="True" />
+        </cycle>
+        <death>
+            <model code="100" name="apoptosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">516</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+            <model code="101" name="necrosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">0</duration>
+                    <duration index="1" fixed_duration="true">86400</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">1.11667e-2</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">8.33333e-4</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">5.33333e-5</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">2.16667e-3</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+        </death>
+        <volume>
+            <total units="micron^3">2494</total>
+            <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+            <nuclear units="micron^3">540</nuclear>
+            <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+            <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+            <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+            <calcified_fraction units="dimensionless">0</calcified_fraction>
+            <calcification_rate units="1/min">0</calcification_rate>
+            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+        </volume>
+        <mechanics>
+            <cell_cell_adhesion_strength units="micron/min">0.4</cell_cell_adhesion_strength>
+            <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+            <relative_maximum_adhesion_distance units="dimensionless">1.25</relative_maximum_adhesion_distance>
+            <cell_adhesion_affinities />
+            <options>
+                <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+            </options>
+            <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+            <attachment_rate units="1/min">0.0</attachment_rate>
+            <detachment_rate units="1/min">0.0</detachment_rate>
+            <maximum_number_of_attachments>12</maximum_number_of_attachments>
+        </mechanics>
+        <motility>
+            <speed units="micron/min">1</speed>
+            <persistence_time units="min">1</persistence_time>
+            <migration_bias units="dimensionless">0.5</migration_bias>
+            <options>
+                <enabled>true</enabled>
+                <use_2D>true</use_2D>
+            </options>
+            </motility>
+            <secretion />
+            <cell_interactions>
+                <apoptotic_phagocytosis_rate units="1/min">0</apoptotic_phagocytosis_rate>
+                <necrotic_phagocytosis_rate units="1/min">0</necrotic_phagocytosis_rate>
+                <other_dead_phagocytosis_rate units="1/min">0</other_dead_phagocytosis_rate>
+                <live_phagocytosis_rates />
+                <attack_rates />
+                <attack_damage_rate units="1/min">1</attack_damage_rate>
+                <fusion_rates />
+            </cell_interactions>
+            <cell_transformations>
+                <transformation_rates />
+            </cell_transformations>
+    </phenotype>
+"""
+
+"Layer 6" = """
+
+    <phenotype>
+        <cycle code="5" name="live">
+            <phase_transition_rates units="1/min">
+                <rate start_index="0" end_index="0" fixed_duration="false">0</rate>
+            </phase_transition_rates>
+            <standard_asymmetric_division enabled="False" />
+        </cycle>
+        <death>
+            <model code="100" name="apoptosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">516</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+            <model code="101" name="necrosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">0</duration>
+                    <duration index="1" fixed_duration="true">86400</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">1.11667e-2</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">8.33333e-4</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">5.33333e-5</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">2.16667e-3</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+        </death>
+        <volume>
+            <total units="micron^3">2494</total>
+            <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+            <nuclear units="micron^3">540</nuclear>
+            <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+            <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+            <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+            <calcified_fraction units="dimensionless">0</calcified_fraction>
+            <calcification_rate units="1/min">0</calcification_rate>
+            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+        </volume>
+        <mechanics>
+            <cell_cell_adhesion_strength units="micron/min">0</cell_cell_adhesion_strength>
+            <cell_cell_repulsion_strength units="micron/min">10</cell_cell_repulsion_strength>
+            <relative_maximum_adhesion_distance units="dimensionless">1.25</relative_maximum_adhesion_distance>
+            <cell_adhesion_affinities />
+            <options>
+                <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+            </options>
+            <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+            <attachment_rate units="1/min">0.0</attachment_rate>
+            <detachment_rate units="1/min">0.0</detachment_rate>
+            <maximum_number_of_attachments>12</maximum_number_of_attachments>
+        </mechanics>
+        <motility>
+            <speed units="micron/min">0</speed>
+            <persistence_time units="min">1</persistence_time>
+            <migration_bias units="dimensionless">.5</migration_bias>
+            <options>
+                <enabled>false</enabled>
+                <use_2D>true</use_2D>
+            </options>
+        </motility>
+        <secretion />
+        <cell_interactions>
+            <apoptotic_phagocytosis_rate units="1/min">0</apoptotic_phagocytosis_rate>
+            <necrotic_phagocytosis_rate units="1/min">0</necrotic_phagocytosis_rate>
+            <other_dead_phagocytosis_rate units="1/min">0</other_dead_phagocytosis_rate>
+            <live_phagocytosis_rates />
+            <attack_rates />
+            <attack_damage_rate units="1/min">1</attack_damage_rate>
+            <fusion_rates />
+        </cell_interactions>
+        <cell_transformations>
+            <transformation_rates />
+        </cell_transformations>
+    </phenotype>
+"""
+
+"Layer 5" = """
+
+    <phenotype>
+        <cycle code="5" name="live">
+            <phase_transition_rates units="1/min">
+                <rate start_index="0" end_index="0" fixed_duration="false">0</rate>
+            </phase_transition_rates>
+            <standard_asymmetric_division enabled="False" />
+        </cycle>
+        <death>
+            <model code="100" name="apoptosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">516</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+            <model code="101" name="necrosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">0</duration>
+                    <duration index="1" fixed_duration="true">86400</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">1.11667e-2</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">8.33333e-4</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">5.33333e-5</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">2.16667e-3</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+        </death>
+        <volume>
+            <total units="micron^3">2494</total>
+            <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+            <nuclear units="micron^3">540</nuclear>
+            <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+            <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+            <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+            <calcified_fraction units="dimensionless">0</calcified_fraction>
+            <calcification_rate units="1/min">0</calcification_rate>
+            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+        </volume>
+        <mechanics>
+            <cell_cell_adhesion_strength units="micron/min">0</cell_cell_adhesion_strength>
+            <cell_cell_repulsion_strength units="micron/min">10</cell_cell_repulsion_strength>
+            <relative_maximum_adhesion_distance units="dimensionless">1.25</relative_maximum_adhesion_distance>
+            <cell_adhesion_affinities />
+            <options>
+                <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+            </options>
+            <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+            <attachment_rate units="1/min">0.0</attachment_rate>
+            <detachment_rate units="1/min">0.0</detachment_rate>
+            <maximum_number_of_attachments>12</maximum_number_of_attachments>
+        </mechanics>
+        <motility>
+            <speed units="micron/min">2</speed>
+            <persistence_time units="min">1</persistence_time>
+            <migration_bias units="dimensionless">.5</migration_bias>
+            <options>
+                <enabled>true</enabled>
+                <use_2D>true</use_2D>
+            </options>
+        </motility>
+        <secretion />
+        <cell_interactions>
+            <apoptotic_phagocytosis_rate units="1/min">0</apoptotic_phagocytosis_rate>
+            <necrotic_phagocytosis_rate units="1/min">0</necrotic_phagocytosis_rate>
+            <other_dead_phagocytosis_rate units="1/min">0</other_dead_phagocytosis_rate>
+            <live_phagocytosis_rates />
+            <attack_rates />
+            <attack_damage_rate units="1/min">1</attack_damage_rate>
+            <fusion_rates />
+        </cell_interactions>
+        <cell_transformations>
+            <transformation_rates />
+        </cell_transformations>
+    </phenotype>
+"""
+
+"Layer 3" = """
+
+    <phenotype>
+        <cycle code="5" name="live">
+            <phase_transition_rates units="1/min">
+                <rate start_index="0" end_index="0" fixed_duration="false">0</rate>
+            </phase_transition_rates>
+            <standard_asymmetric_division enabled="False" />
+        </cycle>
+        <death>
+            <model code="100" name="apoptosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">516</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+            <model code="101" name="necrosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">0</duration>
+                    <duration index="1" fixed_duration="true">86400</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">1.11667e-2</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">8.33333e-4</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">5.33333e-5</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">2.16667e-3</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+        </death>
+        <volume>
+            <total units="micron^3">2494</total>
+            <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+            <nuclear units="micron^3">540</nuclear>
+            <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+            <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+            <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+            <calcified_fraction units="dimensionless">0</calcified_fraction>
+            <calcification_rate units="1/min">0</calcification_rate>
+            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+        </volume>
+        <mechanics>
+            <cell_cell_adhesion_strength units="micron/min">0</cell_cell_adhesion_strength>
+            <cell_cell_repulsion_strength units="micron/min">10</cell_cell_repulsion_strength>
+            <relative_maximum_adhesion_distance units="dimensionless">1.25</relative_maximum_adhesion_distance>
+            <cell_adhesion_affinities />
+            <options>
+                <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+            </options>
+            <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+            <attachment_rate units="1/min">0.0</attachment_rate>
+            <detachment_rate units="1/min">0.0</detachment_rate>
+            <maximum_number_of_attachments>12</maximum_number_of_attachments>
+        </mechanics>
+        <motility>
+            <speed units="micron/min">2</speed>
+            <persistence_time units="min">1</persistence_time>
+            <migration_bias units="dimensionless">.5</migration_bias>
+            <options>
+                <enabled>true</enabled>
+                <use_2D>true</use_2D>
+            </options>
+        </motility>
+        <secretion />
+        <cell_interactions>
+            <apoptotic_phagocytosis_rate units="1/min">0</apoptotic_phagocytosis_rate>
+            <necrotic_phagocytosis_rate units="1/min">0</necrotic_phagocytosis_rate>
+            <other_dead_phagocytosis_rate units="1/min">0</other_dead_phagocytosis_rate>
+            <live_phagocytosis_rates />
+            <attack_rates />
+            <attack_damage_rate units="1/min">1</attack_damage_rate>
+            <fusion_rates />
+        </cell_interactions>
+        <cell_transformations>
+            <transformation_rates />
+        </cell_transformations>
+    </phenotype>
+"""
+
+"Layer 2" = """
+
+    <phenotype>
+        <cycle code="5" name="live">
+            <phase_transition_rates units="1/min">
+                <rate start_index="0" end_index="0" fixed_duration="false">0</rate>
+            </phase_transition_rates>
+            <standard_asymmetric_division enabled="False" />
+        </cycle>
+        <death>
+            <model code="100" name="apoptosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">516</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+            <model code="101" name="necrosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">0</duration>
+                    <duration index="1" fixed_duration="true">86400</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">1.11667e-2</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">8.33333e-4</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">5.33333e-5</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">2.16667e-3</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+        </death>
+        <volume>
+            <total units="micron^3">2494</total>
+            <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+            <nuclear units="micron^3">540</nuclear>
+            <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+            <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+            <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+            <calcified_fraction units="dimensionless">0</calcified_fraction>
+            <calcification_rate units="1/min">0</calcification_rate>
+            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+        </volume>
+        <mechanics>
+            <cell_cell_adhesion_strength units="micron/min">0</cell_cell_adhesion_strength>
+            <cell_cell_repulsion_strength units="micron/min">10</cell_cell_repulsion_strength>
+            <relative_maximum_adhesion_distance units="dimensionless">1.25</relative_maximum_adhesion_distance>
+            <cell_adhesion_affinities>
+                <cell_adhesion_affinity name="apical">1.0</cell_adhesion_affinity>
+                <cell_adhesion_affinity name="pial">0.0</cell_adhesion_affinity>
+                <cell_adhesion_affinity name="rgc">1.0</cell_adhesion_affinity>
+                <cell_adhesion_affinity name="layer_6">0.0</cell_adhesion_affinity>
+                <cell_adhesion_affinity name="layer_5">0.0</cell_adhesion_affinity>
+                <cell_adhesion_affinity name="layer_4">0.0</cell_adhesion_affinity>
+                <cell_adhesion_affinity name="layer_3">0.0</cell_adhesion_affinity>
+                <cell_adhesion_affinity name="layer_2">0.0</cell_adhesion_affinity>
+            </cell_adhesion_affinities>
+            <options>
+                <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+            </options>
+            <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+            <attachment_rate units="1/min">0.0</attachment_rate>
+            <detachment_rate units="1/min">0.0</detachment_rate>
+            <maximum_number_of_attachments>12</maximum_number_of_attachments>
+        </mechanics>
+        <motility>
+            <speed units="micron/min">2</speed>
+            <persistence_time units="min">1</persistence_time>
+            <migration_bias units="dimensionless">.5</migration_bias>
+            <options>
+                <enabled>true</enabled>
+                <use_2D>true</use_2D>
+                <advanced_chemotaxis>
+                    <enabled>false</enabled>
+                    <normalize_each_gradient>false</normalize_each_gradient>
+                    <chemotactic_sensitivities />
+                </advanced_chemotaxis>
+            </options>
+        </motility>
+        <secretion />
+        <cell_interactions>
+            <apoptotic_phagocytosis_rate units="1/min">0.0</apoptotic_phagocytosis_rate>
+            <necrotic_phagocytosis_rate units="1/min">0.0</necrotic_phagocytosis_rate>
+            <other_dead_phagocytosis_rate units="1/min">0.0</other_dead_phagocytosis_rate>
+            <live_phagocytosis_rates>
+                <phagocytosis_rate name="default" units="1/min">0</phagocytosis_rate>
+            </live_phagocytosis_rates>
+            <attack_rates>
+                <attack_rate name="default" units="1/min">0</attack_rate>
+            </attack_rates>
+            <attack_damage_rate units="1/min">1</attack_damage_rate>
+            <attack_duration units="min">0.1</attack_duration>
+            <fusion_rates>
+                <fusion_rate name="default" units="1/min">0</fusion_rate>
+            </fusion_rates>
+        </cell_interactions>
+        <cell_transformations>
+            <transformation_rates>
+                <transformation_rate name="default" units="1/min">0</transformation_rate>
+            </transformation_rates>
+        </cell_transformations>
+        <cell_integrity>
+            <damage_rate units="1/min">0.0</damage_rate>
+            <damage_repair_rate units="1/min">0.0</damage_repair_rate>
+        </cell_integrity>
+    </phenotype>
+"""
+
+"PD-L1lo Tumor" = """
+
+    <phenotype>
+        <cycle code="5" name="live">
+            <phase_transition_rates units="1/min">
+                <rate start_index="0" end_index="0" fixed_duration="false">7.20E-04</rate>
+            </phase_transition_rates>
+        </cycle>
+        <death>
+            <model code="100" name="apoptosis">
+                <death_rate units="1/min">7.2e-5</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">516</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+            <model code="101" name="necrosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">0</duration>
+                    <duration index="1" fixed_duration="true">86400</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+        </death>
+        <volume>
+            <total units="micron^3">2494</total>
+            <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+            <nuclear units="micron^3">540</nuclear>
+            <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+            <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+            <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+            <calcified_fraction units="dimensionless">0</calcified_fraction>
+            <calcification_rate units="1/min">0</calcification_rate>
+            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+        </volume>
+        <mechanics>
+            <cell_cell_adhesion_strength units="micron/min">0.4</cell_cell_adhesion_strength>
+            <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+            <relative_maximum_adhesion_distance units="dimensionless">1.5</relative_maximum_adhesion_distance>
+            <cell_adhesion_affinities />
+            <options>
+                <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+            </options>
+            <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+            <attachment_rate units="1/min">0</attachment_rate>
+            <detachment_rate units="1/min">0.0</detachment_rate>
+            <maximum_number_of_attachments>12</maximum_number_of_attachments>
+        </mechanics>
+        <motility>
+            <speed units="micron/min">0.5</speed>
+            <persistence_time units="min">5</persistence_time>
+            <migration_bias units="dimensionless">0.1</migration_bias>
+            <options>
+                <enabled>false</enabled>
+                <use_2D>true</use_2D>
+            </options>
+        </motility>
+        <secretion />
+        <cell_interactions>
+            <apoptotic_phagocytosis_rate units="1/min">0.0</apoptotic_phagocytosis_rate>
+            <necrotic_phagocytosis_rate units="1/min">0.0</necrotic_phagocytosis_rate>
+            <other_dead_phagocytosis_rate units="1/min">0.0</other_dead_phagocytosis_rate>
+            <live_phagocytosis_rates>
+                <phagocytosis_rate name="default" units="1/min">0</phagocytosis_rate>
+            </live_phagocytosis_rates>
+            <attack_rates>
+                <attack_rate name="default" units="1/min">0</attack_rate>
+            </attack_rates>
+            <attack_damage_rate units="1/min">1</attack_damage_rate>
+            <attack_duration units="min">0.1</attack_duration>
+            <fusion_rates>
+                <fusion_rate name="default" units="1/min">0</fusion_rate>
+            </fusion_rates>
+        </cell_interactions>
+        <cell_transformations>
+            <transformation_rates>
+                <transformation_rate name="default" units="1/min">0</transformation_rate>
+            </transformation_rates>
+        </cell_transformations>
+        <cell_integrity>
+            <damage_rate units="1/min">0.0</damage_rate>
+            <damage_repair_rate units="1/min">0.0</damage_repair_rate>
+        </cell_integrity>
+    </phenotype>
+"""
+
+"PD-L1hi Tumor" = """
+
+    <phenotype>
+        <cycle code="5" name="live">
+            <phase_transition_rates units="1/min">
+                <rate start_index="0" end_index="0" fixed_duration="false">7.20E-04</rate>
+            </phase_transition_rates>
+        </cycle>
+        <death>
+            <model code="100" name="apoptosis">
+                <death_rate units="1/min">7.2e-5</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">516</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+            <model code="101" name="necrosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">0</duration>
+                    <duration index="1" fixed_duration="true">86400</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+        </death>
+        <volume>
+            <total units="micron^3">2494</total>
+            <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+            <nuclear units="micron^3">540</nuclear>
+            <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+            <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+            <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+            <calcified_fraction units="dimensionless">0</calcified_fraction>
+            <calcification_rate units="1/min">0</calcification_rate>
+            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+        </volume>
+        <mechanics>
+            <cell_cell_adhesion_strength units="micron/min">0.4</cell_cell_adhesion_strength>
+            <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+            <relative_maximum_adhesion_distance units="dimensionless">1.5</relative_maximum_adhesion_distance>
+            <cell_adhesion_affinities />
+            <options>
+                <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+            </options>
+            <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+            <attachment_rate units="1/min">0</attachment_rate>
+            <detachment_rate units="1/min">0.0</detachment_rate>
+            <maximum_number_of_attachments>12</maximum_number_of_attachments>
+        </mechanics>
+        <motility>
+            <speed units="micron/min">0.5</speed>
+            <persistence_time units="min">5</persistence_time>
+            <migration_bias units="dimensionless">0.1</migration_bias>
+            <options>
+                <enabled>false</enabled>
+                <use_2D>true</use_2D>
+            </options>
+        </motility>
+        <secretion />
+        <cell_interactions>
+            <apoptotic_phagocytosis_rate units="1/min">0.0</apoptotic_phagocytosis_rate>
+            <necrotic_phagocytosis_rate units="1/min">0.0</necrotic_phagocytosis_rate>
+            <other_dead_phagocytosis_rate units="1/min">0.0</other_dead_phagocytosis_rate>
+            <live_phagocytosis_rates>
+                <phagocytosis_rate name="default" units="1/min">0</phagocytosis_rate>
+            </live_phagocytosis_rates>
+            <attack_rates>
+                <attack_rate name="default" units="1/min">0</attack_rate>
+            </attack_rates>
+            <attack_damage_rate units="1/min">1</attack_damage_rate>
+            <attack_duration units="min">0.1</attack_duration>
+            <fusion_rates>
+                <fusion_rate name="default" units="1/min">0</fusion_rate>
+            </fusion_rates>
+        </cell_interactions>
+        <cell_transformations>
+            <transformation_rates>
+                <transformation_rate name="default" units="1/min">0</transformation_rate>
+            </transformation_rates>
+        </cell_transformations>
+        <cell_integrity>
+            <damage_rate units="1/min">0.0</damage_rate>
+            <damage_repair_rate units="1/min">0.0</damage_repair_rate>
+        </cell_integrity>
+    </phenotype>
+"""
+
+"PD-1hi CD137lo CD8 T Cell" = """
+
+    <phenotype>
+        <cycle code="5" name="live">
+            <phase_transition_rates units="1/min">
+                <rate start_index="0" end_index="0" fixed_duration="false">0</rate>
+            </phase_transition_rates>
+        </cycle>
+        <death>
+            <model code="100" name="apoptosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">516</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+            <model code="101" name="necrosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">0</duration>
+                    <duration index="1" fixed_duration="true">86400</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+        </death>
+        <volume>
+            <total units="micron^3">2494</total>
+            <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+            <nuclear units="micron^3">540</nuclear>
+            <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+            <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+            <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+            <calcified_fraction units="dimensionless">0</calcified_fraction>
+            <calcification_rate units="1/min">0</calcification_rate>
+            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+        </volume>
+        <mechanics>
+            <cell_cell_adhesion_strength units="micron/min">0</cell_cell_adhesion_strength>
+            <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+            <relative_maximum_adhesion_distance units="dimensionless">1.5</relative_maximum_adhesion_distance>
+            <cell_adhesion_affinities />
+            <options>
+                <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+            </options>
+            <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+            <attachment_rate units="1/min">0</attachment_rate>
+            <detachment_rate units="1/min">0.0</detachment_rate>
+            <maximum_number_of_attachments>12</maximum_number_of_attachments>
+        </mechanics>
+        <motility>
+            <speed units="micron/min">1</speed>
+            <persistence_time units="min">5</persistence_time>
+            <migration_bias units="dimensionless">0.5</migration_bias>
+            <options>
+                <enabled>true</enabled>
+                <use_2D>true</use_2D>
+            </options>
+        </motility>
+            <secretion />
+            <cell_interactions>
+                <apoptotic_phagocytosis_rate units="1/min">0.0</apoptotic_phagocytosis_rate>
+                <necrotic_phagocytosis_rate units="1/min">0.0</necrotic_phagocytosis_rate>
+                <other_dead_phagocytosis_rate units="1/min">0.0</other_dead_phagocytosis_rate>
+                <live_phagocytosis_rates>
+                    <phagocytosis_rate name="default" units="1/min">0</phagocytosis_rate>
+                </live_phagocytosis_rates>
+                <attack_rates>
+                    <attack_rate name="default" units="1/min">0</attack_rate>
+                </attack_rates>
+                <attack_damage_rate units="1/min">1</attack_damage_rate>
+                <attack_duration units="min">0.1</attack_duration>
+                <fusion_rates>
+                    <fusion_rate name="default" units="1/min">0</fusion_rate>
+                </fusion_rates>
+            </cell_interactions>
+            <cell_transformations>
+                <transformation_rates>
+                    <transformation_rate name="default" units="1/min">0</transformation_rate>
+                </transformation_rates>
+            </cell_transformations>
+            <cell_integrity>
+                <damage_rate units="1/min">0.0</damage_rate>
+                <damage_repair_rate units="1/min">0.0</damage_repair_rate>
+            </cell_integrity>
+    </phenotype>
+"""
+
+"PD-1lo CD137lo CD8 T Cell" = """
+
+    <phenotype>
+        <cycle code="5" name="live">
+            <phase_transition_rates units="1/min">
+                <rate start_index="0" end_index="0" fixed_duration="false">0</rate>
+            </phase_transition_rates>
+        </cycle>
+        <death>
+            <model code="100" name="apoptosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">516</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+            <model code="101" name="necrosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">0</duration>
+                    <duration index="1" fixed_duration="true">86400</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+        </death>
+        <volume>
+            <total units="micron^3">2494</total>
+            <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+            <nuclear units="micron^3">540</nuclear>
+            <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+            <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+            <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+            <calcified_fraction units="dimensionless">0</calcified_fraction>
+            <calcification_rate units="1/min">0</calcification_rate>
+            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+        </volume>
+        <mechanics>
+            <cell_cell_adhesion_strength units="micron/min">0</cell_cell_adhesion_strength>
+            <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+            <relative_maximum_adhesion_distance units="dimensionless">1.5</relative_maximum_adhesion_distance>
+            <cell_adhesion_affinities />
+            <options>
+                <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+            </options>
+            <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+            <attachment_rate units="1/min">0</attachment_rate>
+            <detachment_rate units="1/min">0.0</detachment_rate>
+            <maximum_number_of_attachments>12</maximum_number_of_attachments>
+        </mechanics>
+        <motility>
+            <speed units="micron/min">1</speed>
+            <persistence_time units="min">5</persistence_time>
+            <migration_bias units="dimensionless">0.5</migration_bias>
+            <options>
+                <enabled>true</enabled>
+                <use_2D>true</use_2D>
+            </options>
+        </motility>
+        <secretion />
+        <cell_interactions>
+            <apoptotic_phagocytosis_rate units="1/min">0.0</apoptotic_phagocytosis_rate>
+            <necrotic_phagocytosis_rate units="1/min">0.0</necrotic_phagocytosis_rate>
+            <other_dead_phagocytosis_rate units="1/min">0.0</other_dead_phagocytosis_rate>
+            <live_phagocytosis_rates>
+                <phagocytosis_rate name="default" units="1/min">0</phagocytosis_rate>
+            </live_phagocytosis_rates>
+            <attack_rates>
+                <attack_rate name="default" units="1/min">0</attack_rate>
+            </attack_rates>
+            <attack_damage_rate units="1/min">1</attack_damage_rate>
+            <attack_duration units="min">0.1</attack_duration>
+            <fusion_rates>
+                <fusion_rate name="default" units="1/min">0</fusion_rate>
+            </fusion_rates>
+        </cell_interactions>
+        <cell_transformations>
+            <transformation_rates>
+                <transformation_rate name="default" units="1/min">0</transformation_rate>
+            </transformation_rates>
+        </cell_transformations>
+        <cell_integrity>
+            <damage_rate units="1/min">0.0</damage_rate>
+            <damage_repair_rate units="1/min">0.0</damage_repair_rate>
+        </cell_integrity>
+    </phenotype>
+"""
+
+"PD-1hi CD137hi CD8 T Cell" = """
+
+    <phenotype>
+        <cycle code="5" name="live">
+            <phase_transition_rates units="1/min">
+                <rate start_index="0" end_index="0" fixed_duration="false">0</rate>
+            </phase_transition_rates>
+        </cycle>
+        <death>
+            <model code="100" name="apoptosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">516</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+            <model code="101" name="necrosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">0</duration>
+                    <duration index="1" fixed_duration="true">86400</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+        </death>
+        <volume>
+            <total units="micron^3">2494</total>
+            <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+            <nuclear units="micron^3">540</nuclear>
+            <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+            <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+            <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+            <calcified_fraction units="dimensionless">0</calcified_fraction>
+            <calcification_rate units="1/min">0</calcification_rate>
+            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+        </volume>
+        <mechanics>
+            <cell_cell_adhesion_strength units="micron/min">0</cell_cell_adhesion_strength>
+            <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+            <relative_maximum_adhesion_distance units="dimensionless">1.5</relative_maximum_adhesion_distance>
+            <cell_adhesion_affinities />
+            <options>
+                <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+            </options>
+            <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+            <attachment_rate units="1/min">0</attachment_rate>
+            <detachment_rate units="1/min">0.0</detachment_rate>
+            <maximum_number_of_attachments>12</maximum_number_of_attachments>
+        </mechanics>
+        <motility>
+            <speed units="micron/min">1</speed>
+            <persistence_time units="min">5</persistence_time>
+            <migration_bias units="dimensionless">0.5</migration_bias>
+            <options>
+                <enabled>true</enabled>
+                <use_2D>true</use_2D>
+            </options>
+        </motility>
+        <secretion />
+        <cell_interactions>
+            <apoptotic_phagocytosis_rate units="1/min">0.0</apoptotic_phagocytosis_rate>
+            <necrotic_phagocytosis_rate units="1/min">0.0</necrotic_phagocytosis_rate>
+            <other_dead_phagocytosis_rate units="1/min">0.0</other_dead_phagocytosis_rate>
+            <live_phagocytosis_rates>
+                <phagocytosis_rate name="default" units="1/min">0</phagocytosis_rate>
+            </live_phagocytosis_rates>
+            <attack_rates>
+                <attack_rate name="default" units="1/min">0</attack_rate>
+            </attack_rates>
+            <attack_damage_rate units="1/min">1</attack_damage_rate>
+            <attack_duration units="min">0.1</attack_duration>
+            <fusion_rates>
+                <fusion_rate name="default" units="1/min">0</fusion_rate>
+            </fusion_rates>
+        </cell_interactions>
+        <cell_transformations>
+            <transformation_rates>
+                <transformation_rate name="default" units="1/min">0</transformation_rate>
+            </transformation_rates>
+        </cell_transformations>
+        <cell_integrity>
+            <damage_rate units="1/min">0.0</damage_rate>
+            <damage_repair_rate units="1/min">0.0</damage_repair_rate>
+        </cell_integrity>
+    </phenotype>
+"""
+
+"PD-1lo CD137hi CD8 T Cell" = """
+
+    <phenotype>
+        <cycle code="5" name="live">
+            <phase_transition_rates units="1/min">
+                <rate start_index="0" end_index="0" fixed_duration="false">0</rate>
+            </phase_transition_rates>
+        </cycle>
+        <death>
+            <model code="100" name="apoptosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">516</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+            <model code="101" name="necrosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">0</duration>
+                    <duration index="1" fixed_duration="true">86400</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+        </death>
+        <volume>
+            <total units="micron^3">2494</total>
+            <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+            <nuclear units="micron^3">540</nuclear>
+            <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+            <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+            <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+            <calcified_fraction units="dimensionless">0</calcified_fraction>
+            <calcification_rate units="1/min">0</calcification_rate>
+            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+        </volume>
+        <mechanics>
+            <cell_cell_adhesion_strength units="micron/min">0</cell_cell_adhesion_strength>
+            <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+            <relative_maximum_adhesion_distance units="dimensionless">1.5</relative_maximum_adhesion_distance>
+            <cell_adhesion_affinities />
+            <options>
+                <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+            </options>
+            <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+            <attachment_rate units="1/min">0</attachment_rate>
+            <detachment_rate units="1/min">0.0</detachment_rate>
+            <maximum_number_of_attachments>12</maximum_number_of_attachments>
+        </mechanics>
+        <motility>
+            <speed units="micron/min">1</speed>
+            <persistence_time units="min">5</persistence_time>
+            <migration_bias units="dimensionless">0.5</migration_bias>
+            <options>
+                <enabled>true</enabled>
+                <use_2D>true</use_2D>
+            </options>
+        </motility>
+        <secretion />
+        <cell_interactions>
+            <apoptotic_phagocytosis_rate units="1/min">0.0</apoptotic_phagocytosis_rate>
+            <necrotic_phagocytosis_rate units="1/min">0.0</necrotic_phagocytosis_rate>
+            <other_dead_phagocytosis_rate units="1/min">0.0</other_dead_phagocytosis_rate>
+            <live_phagocytosis_rates>
+                <phagocytosis_rate name="default" units="1/min">0</phagocytosis_rate>
+            </live_phagocytosis_rates>
+            <attack_rates>
+                <attack_rate name="default" units="1/min">0</attack_rate>
+            </attack_rates>
+            <attack_damage_rate units="1/min">1</attack_damage_rate>
+            <attack_duration units="min">0.1</attack_duration>
+            <fusion_rates>
+                <fusion_rate name="default" units="1/min">0</fusion_rate>
+            </fusion_rates>
+        </cell_interactions>
+        <cell_transformations>
+            <transformation_rates>
+                <transformation_rate name="default" units="1/min">0</transformation_rate>
+            </transformation_rates>
+        </cell_transformations>
+        <cell_integrity>
+            <damage_rate units="1/min">0.0</damage_rate>
+            <damage_repair_rate units="1/min">0.0</damage_repair_rate>
+        </cell_integrity>
+    </phenotype>
+"""
+
+"PD-1lo CD4 T Cell" = """
+
+    <phenotype>
+        <cycle code="5" name="live">
+            <phase_transition_rates units="1/min">
+                <rate start_index="0" end_index="0" fixed_duration="false">0</rate>
+            </phase_transition_rates>
+        </cycle>
+        <death>
+            <model code="100" name="apoptosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">516</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+            <model code="101" name="necrosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">0</duration>
+                    <duration index="1" fixed_duration="true">86400</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+        </death>
+        <volume>
+            <total units="micron^3">2494</total>
+            <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+            <nuclear units="micron^3">540</nuclear>
+            <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+            <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+            <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+            <calcified_fraction units="dimensionless">0</calcified_fraction>
+            <calcification_rate units="1/min">0</calcification_rate>
+            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+        </volume>
+        <mechanics>
+            <cell_cell_adhesion_strength units="micron/min">0</cell_cell_adhesion_strength>
+            <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+            <relative_maximum_adhesion_distance units="dimensionless">1.5</relative_maximum_adhesion_distance>
+            <cell_adhesion_affinities />
+            <options>
+                <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+            </options>
+            <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+            <attachment_rate units="1/min">0</attachment_rate>
+            <detachment_rate units="1/min">0.0</detachment_rate>
+            <maximum_number_of_attachments>12</maximum_number_of_attachments>
+        </mechanics>
+        <motility>
+            <speed units="micron/min">1</speed>
+            <persistence_time units="min">5</persistence_time>
+            <migration_bias units="dimensionless">0.25</migration_bias>
+            <options>
+                <enabled>true</enabled>
+                <use_2D>true</use_2D>
+            </options>
+        </motility>
+        <secretion />
+        <cell_interactions>
+            <apoptotic_phagocytosis_rate units="1/min">0.0</apoptotic_phagocytosis_rate>
+            <necrotic_phagocytosis_rate units="1/min">0.0</necrotic_phagocytosis_rate>
+            <other_dead_phagocytosis_rate units="1/min">0.0</other_dead_phagocytosis_rate>
+            <live_phagocytosis_rates>
+                <phagocytosis_rate name="default" units="1/min">0</phagocytosis_rate>
+            </live_phagocytosis_rates>
+            <attack_rates>
+                <attack_rate name="default" units="1/min">0</attack_rate>
+            </attack_rates>
+            <attack_damage_rate units="1/min">1</attack_damage_rate>
+            <attack_duration units="min">0.1</attack_duration>
+            <fusion_rates>
+                <fusion_rate name="default" units="1/min">0</fusion_rate>
+            </fusion_rates>
+        </cell_interactions>
+        <cell_transformations>
+            <transformation_rates>
+                <transformation_rate name="default" units="1/min">0</transformation_rate>
+            </transformation_rates>
+        </cell_transformations>
+        <cell_integrity>
+            <damage_rate units="1/min">0.0</damage_rate>
+            <damage_repair_rate units="1/min">0.0</damage_repair_rate>
+        </cell_integrity>
+    </phenotype>
+"""
+
+"CD8 T Cell" = """
+
+    <phenotype>
+        <cycle code="5" name="live">
+            <phase_transition_rates units="1/min">
+                <rate start_index="0" end_index="0" fixed_duration="false">0</rate>
+            </phase_transition_rates>
+            <standard_asymmetric_division enabled="False" />
+        </cycle>
+        <death>
+            <model code="100" name="apoptosis">
+                <death_rate units="1/min">0</death_rate>
+                <phase_transition_rates units="1/min">
+                    <rate start_index="0" end_index="1" fixed_duration="false">0.001938</rate>
+                </phase_transition_rates>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+            <model code="101" name="necrosis">
+                <death_rate units="1/min">0.0</death_rate>
+                <phase_transition_rates units="1/min">
+                    <rate start_index="0" end_index="1" fixed_duration="false">9000000000.0</rate>
+                    <rate start_index="1" end_index="2" fixed_duration="true">1.15741e-05</rate>
+                </phase_transition_rates>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">1.11667e-02</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">8.33333e-4</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">5.33333e-05</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">2.16667e-4</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">7e-05</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+        </death>
+        <volume>
+            <total units="micron^3">2494</total>
+            <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+            <nuclear units="micron^3">540</nuclear>
+            <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+            <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+            <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+            <calcified_fraction units="dimensionless">0.0</calcified_fraction>
+            <calcification_rate units="1/min">0.0</calcification_rate>
+            <relative_rupture_volume units="dimensionless">2</relative_rupture_volume>
+        </volume>
+        <mechanics>
+            <cell_cell_adhesion_strength units="micron/min">0</cell_cell_adhesion_strength>
+            <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+            <relative_maximum_adhesion_distance units="dimensionless">1.25</relative_maximum_adhesion_distance>
+            <cell_adhesion_affinities />
+            <options>
+                <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+            </options>
+            <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+            <attachment_rate units="1/min">0.0</attachment_rate>
+            <detachment_rate units="1/min">0.0</detachment_rate>
+            <maximum_number_of_attachments>12</maximum_number_of_attachments>
+        </mechanics>
+        <motility>
+            <speed units="micron/min">1.0</speed>
+            <persistence_time units="min">5</persistence_time>
+            <migration_bias units="dimensionless">0.5</migration_bias>
+            <options>
+                <enabled>true</enabled>
+                <use_2D>true</use_2D>
+            </options>
+        </motility>
+        <secretion />
+        <cell_interactions>
+            <apoptotic_phagocytosis_rate units="1/min">0.0</apoptotic_phagocytosis_rate>
+            <necrotic_phagocytosis_rate units="1/min">0.0</necrotic_phagocytosis_rate>
+            <other_dead_phagocytosis_rate units="1/min">0.0</other_dead_phagocytosis_rate>
+            <live_phagocytosis_rates>
+                <phagocytosis_rate name="default" units="1/min">0</phagocytosis_rate>
+            </live_phagocytosis_rates>
+            <attack_rates>
+                <attack_rate name="default" units="1/min">0</attack_rate>
+            </attack_rates>
+            <attack_damage_rate units="1/min">1</attack_damage_rate>
+            <attack_duration units="min">0.1</attack_duration>
+            <fusion_rates>
+                <fusion_rate name="default" units="1/min">0</fusion_rate>
+            </fusion_rates>
+        </cell_interactions>
+        <cell_transformations>
+            <transformation_rates>
+                <transformation_rate name="default" units="1/min">0</transformation_rate>
+            </transformation_rates>
+        </cell_transformations>
+        <cell_integrity>
+            <damage_rate units="1/min">0.0</damage_rate>
+            <damage_repair_rate units="1/min">0.0</damage_repair_rate>
+        </cell_integrity>
+    </phenotype>
+"""
+

--- a/bin/ics_tab.py
+++ b/bin/ics_tab.py
@@ -11,6 +11,7 @@ Rf. Credits.md
 import sys
 import os
 import logging
+import math
 import time
 import csv
 # import xml.etree.ElementTree as ET  # https://docs.python.org/2/library/xml.etree.elementtree.html
@@ -27,7 +28,7 @@ from collections import deque
 import glob
 
 from PyQt5 import QtCore, QtGui
-from PyQt5.QtWidgets import QFrame,QApplication,QWidget,QTabWidget,QFormLayout,QLineEdit, QHBoxLayout,QVBoxLayout,QRadioButton,QLabel,QCheckBox,QComboBox,QScrollArea,  QMainWindow,QGridLayout, QPushButton, QFileDialog, QMessageBox, QStackedWidget, QSplitter
+from PyQt5.QtWidgets import QFrame,QApplication,QWidget,QTabWidget,QFormLayout,QLineEdit, QHBoxLayout,QVBoxLayout,QLabel,QCheckBox,QComboBox,QScrollArea,  QMainWindow,QGridLayout, QPushButton, QFileDialog, QMessageBox, QStackedWidget, QSplitter
 from PyQt5.QtGui import QPixmap
 from PyQt5.QtGui import QRegExpValidator
 
@@ -2302,179 +2303,108 @@ class ICs(StudioTab):
         msgBox.setStandardButtons(QMessageBox.Ok)
         msgBox.exec()
 
-    def _create_biwt_package_tab(self):
-        """Build the BIWT widget from the installed biwt package."""
-        ct = self.xml_creator.config_tab
-        try:
-            domain = DomainSpec(
-                xmin=float(ct.xmin.text()),
-                xmax=float(ct.xmax.text()),
-                ymin=float(ct.ymin.text()),
-                ymax=float(ct.ymax.text()),
-            )
-        except (ValueError, AttributeError):
-            domain = DomainSpec(xmin=-500, xmax=500, ymin=-500, ymax=500)
+    def _domain_from_config_tab(self):
+        """A DomainSpec describing this model's domain, or None if it is unusable.
 
-        biwt_input = BiwtInput(preferred_domain=domain, host_name="Studio")
-        return create_biwt_widget(biwt_input, on_complete=self._biwt_complete)
+        All six bounds, z included: BIWT places cells in whatever domain it is given, and
+        Studio offers to adopt the one it gets back. Sending only x and y would leave z at
+        DomainSpec's own -10/+10, so a 3D model would come back as a 2D slab and adopting
+        that would flatten it.
+
+        Usable means what it means to BIWT: every bound a finite number, and lo strictly
+        below hi on every axis. Equal bounds are not usable -- a zero-width axis divides by
+        zero in BIWT's placement scaling.
+
+        Returns None rather than substituting numbers of its own. BiwtInput then falls back
+        to BIWT's default and reports the domain as coming from BIWT, which is true and
+        visible in the completion dialog; quietly passing an invented +/-500 would be
+        reported as coming from Studio, which is not.
+        """
+        names = ("xmin", "xmax", "ymin", "ymax", "zmin", "zmax")
+        try:
+            ct = self.xml_creator.config_tab
+            bounds = {name: float(getattr(ct, name).text()) for name in names}
+        except (ValueError, AttributeError, TypeError):
+            return None
+
+        if not all(math.isfinite(value) for value in bounds.values()):
+            return None
+        for lo, hi in (("xmin", "xmax"), ("ymin", "ymax"), ("zmin", "zmax")):
+            if bounds[lo] >= bounds[hi]:
+                return None
+
+        return DomainSpec(**bounds)
+
+    def _build_biwt_input(self):
+        """What this model currently holds. Called by BIWT at the start of each run.
+
+        Only what can change while Studio is open -- BiwtInput carries nothing else, so the
+        name and the template library are given once, at _create_biwt_package_tab().
+
+        Names BiwtInput and DomainSpec, so it only runs where they imported: reached solely
+        from _create_biwt_package_tab(), itself guarded by HAVE_BIWT_PACKAGE.
+
+        Must not raise. BIWT refuses the import outright if this fails -- no session, no
+        walkthrough, just a dialog naming Studio -- so every read here degrades to a usable
+        default instead. It can be called while Studio is mid-reload, and losing the user's
+        import because a tab was momentarily unreadable would be a poor trade.
+        """
+        # Deliberately broad: the point is that nothing reaches BIWT as an exception. Each of
+        # these is a read of live GUI state whose absence is survivable on its own.
+        try:
+            host_cell_type_names = list(self.xml_creator.celldef_tab.param_d.keys())
+        except Exception:
+            host_cell_type_names = []
+
+        # DomainSpec.default() rather than bounds of Studio's own invention when this model's
+        # domain is unusable: it reports source="default", so BIWT tells the user the domain
+        # came from BIWT. Anything Studio made up would arrive labelled as Studio's.
+        try:
+            domain = self._domain_from_config_tab()
+        except Exception:
+            domain = None
+
+        return BiwtInput(
+            host_cell_type_names=host_cell_type_names,
+            preferred_domain=domain if domain is not None else DomainSpec.default(),
+        )
+
+    def _create_biwt_package_tab(self):
+        """Build the BIWT widget from the installed biwt package.
+
+        The builder is passed rather than a BiwtInput: BIWT calls it when a run starts, so a
+        domain bound or cell type the user changed since the widget was built is picked up
+        without Studio having to notice and push it. The resolved value is snapshotted for the
+        run, so nothing edited mid-walkthrough can move the domain cells are placed into.
+
+        host_name and cell_template_paths go here instead, because they are read once: a
+        library passed per-run would come back after the user removed it at the Cell
+        templates step.
+        """
+        # BIWT ships no phenotype templates of its own -- without cell_template_paths every
+        # dropdown at its Cell templates step offers only "(none)". It seeds the library
+        # rather than pinning it: the user can load further .toml files there, or remove this
+        # one, and BIWT's result may name a file Studio has never seen.
+        try:
+            from biwt_bridge import BUNDLED_TEMPLATE_LIBRARY
+            cell_template_paths = [BUNDLED_TEMPLATE_LIBRARY]
+        except Exception:
+            cell_template_paths = []
+
+        return create_biwt_widget(self._build_biwt_input, on_complete=self._biwt_complete,
+                                  host_name="Studio",
+                                  cell_template_paths=cell_template_paths)
 
     def _biwt_complete(self, result) -> None:
-        """Called by the biwt package when the walkthrough finishes."""
-        import os
-        from PyQt5.QtWidgets import QDialog, QDialogButtonBox
+        """Called by the biwt package when the walkthrough finishes.
 
-        folder = self.csv_folder.text().strip() or "config"
-        fname  = self.output_file.text().strip() or "cells.csv"
-        default_path = os.path.join(folder, fname)
+        Everything past this point -- saving the .csv, deciding what to do with the cell
+        definitions BIWT built, and reconciling them against this model -- lives in
+        biwt_bridge_ui.BiwtCompletionFlow.
+        """
+        from biwt_bridge_ui import BiwtCompletionFlow
 
-        # --- Save CSV dialog (always shown so the user can confirm/change path) ---
-        dlg = QDialog(self)
-        dlg.setWindowTitle("BIWT Complete — Save Cells CSV")
-        vbox = QVBoxLayout(dlg)
-        vbox.addWidget(QLabel("BIWT is complete. Save the cell positions CSV:"))
-
-        path_hbox = QHBoxLayout()
-        path_edit = QLineEdit(default_path)
-        browse_btn = QPushButton("Browse…")
-        path_hbox.addWidget(path_edit, 1)
-        path_hbox.addWidget(browse_btn)
-        vbox.addLayout(path_hbox)
-
-        # Overwrite / Append — shown only when chosen path already exists
-        mode_widget = QWidget()
-        mode_hbox = QHBoxLayout(mode_widget)
-        mode_hbox.setContentsMargins(0, 0, 0, 0)
-        mode_hbox.addWidget(QLabel("File exists — "))
-        overwrite_rb = QRadioButton("Overwrite")
-        append_rb    = QRadioButton("Append to existing")
-        overwrite_rb.setChecked(True)
-        mode_hbox.addWidget(overwrite_rb)
-        mode_hbox.addWidget(append_rb)
-        mode_hbox.addStretch()
-        vbox.addWidget(mode_widget)
-
-        btn_box = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Cancel)
-        btn_box.accepted.connect(dlg.accept)
-        btn_box.rejected.connect(dlg.reject)
-        vbox.addWidget(btn_box)
-
-        def _update_mode():
-            mode_widget.setVisible(os.path.exists(path_edit.text().strip()))
-        def _browse():
-            p, _ = QFileDialog.getSaveFileName(
-                dlg, "Save cells.csv", path_edit.text(),
-                "CSV files (*.csv);;All files (*)",
-            )
-            if p:
-                path_edit.setText(p)
-
-        path_edit.textChanged.connect(_update_mode)
-        browse_btn.clicked.connect(_browse)
-        _update_mode()
-
-        if dlg.exec_() != QDialog.Accepted:
-            return
-
-        out_path = path_edit.text().strip()
-        if not out_path:
-            return
-
-        # Create the target directory if needed (as save_cb() does), otherwise pandas
-        # raises "Cannot save file into a non-existent directory" and the write is lost.
-        # BIWT no longer validates this -- the host owns the write.
-        out_dir = os.path.dirname(out_path)
-        try:
-            if out_dir and not os.path.isdir(out_dir):
-                os.makedirs(out_dir, exist_ok=True)
-
-            if os.path.exists(out_path) and append_rb.isChecked():
-                import pandas as _pd
-                new_rows = result.coordinates[["x", "y", "z", "type"]]
-
-                # A Studio cells CSV starts with x,y,z,type. Let pandas parse the header
-                # (nrows=0 reads columns only) and refuse anything else rather than
-                # trying to reshape it: appending to a file whose columns are ordered
-                # differently would silently write each value into the wrong column.
-                existing_cols = list(_pd.read_csv(out_path, nrows=0).columns)
-                if existing_cols[:4] != ["x", "y", "z", "type"]:
-                    raise ValueError(
-                        f"Cannot append: this file's first four columns are "
-                        f"{existing_cols[:4]}, but a PhysiCell cells CSV must start with "
-                        f"['x', 'y', 'z', 'type']. Pick another file, or overwrite it."
-                    )
-
-                if len(existing_cols) == 4:
-                    # Exactly the columns we write: append in place, no rewrite.
-                    new_rows.to_csv(out_path, mode="a", header=False, index=False)
-                else:
-                    # Extra columns after x,y,z,type (e.g. custom data). Appending only
-                    # four fields would leave a ragged row PhysiCell may not parse, so
-                    # align by name and rewrite, leaving the extras blank for new cells.
-                    existing = _pd.read_csv(out_path)
-                    _pd.concat([existing, new_rows], ignore_index=True).to_csv(out_path, index=False)
-            else:
-                result.to_csv(out_path)
-        except Exception as e:
-            # Deliberately broad: besides OSError, the append path can raise KeyError
-            # if the result lacks the x/y/z/type columns, and a malformed existing CSV
-            # raises from pandas. None of that should take the UI down mid-save.
-            QMessageBox.critical(
-                self,
-                "BIWT — Could not save cells CSV",
-                f"Failed to write '{out_path}':\n\n{type(e).__name__}: {e}",
-            )
-            return
-
-        # Neither BiwtInput nor BiwtResult records the output path -- the host owns
-        # it. Studio's copy lives in these two widgets, read back by save_cb() and
-        # by this method's default_path on the next run.
-        out_folder, out_fname = os.path.split(out_path)
-        self.csv_folder.setText(out_folder or ".")
-        self.output_file.setText(out_fname)
-
-        # --- Cell definitions ---
-        if result.cell_definitions_xml:
-            reply = QMessageBox.question(
-                self,
-                "BIWT — New Cell Definitions",
-                "BIWT generated new cell definitions.\n\n"
-                "Would you like to save these in a new PhysiCell Config file?",
-                QMessageBox.Save | QMessageBox.Cancel,
-                QMessageBox.Save,
-            )
-            if reply != QMessageBox.Save:
-                return
-            xml_path, _ = QFileDialog.getSaveFileName(
-                self, "Save PhysiCell Config",
-                "PhysiCell_settings_biwt.xml",
-                "XML files (*.xml);;All files (*)",
-            )
-            if not xml_path:
-                return
-            try:
-                with open(xml_path, "w", encoding="utf-8") as fh:
-                    fh.write(result.cell_definitions_xml)
-            except Exception as e:
-                # Same reasoning as the CSV save above: report and stop rather than
-                # letting an unwritable path take the UI down, or falling through to
-                # offer a reload of a config that was never written.
-                QMessageBox.critical(
-                    self,
-                    "BIWT — Could not save config XML",
-                    f"Failed to write '{xml_path}':\n\n{type(e).__name__}: {e}",
-                )
-                return
-
-            reload_reply = QMessageBox.question(
-                self,
-                "BIWT — Reload Config?",
-                f"Would you like to reload Studio with {os.path.basename(xml_path)}?",
-                QMessageBox.Ok | QMessageBox.Cancel,
-                QMessageBox.Ok,
-            )
-            if reload_reply == QMessageBox.Ok:
-                self.xml_creator.config_file = xml_path
-                self.xml_creator.show_sample_model()  # misleading name — actually reloads and displays any config file
+        BiwtCompletionFlow(self).run(result)
 
     def fill_gui(self):
         self.csv_folder.setText(self.xml_creator.config_tab.csv_folder.text())

--- a/bin/microenv_tab.py
+++ b/bin/microenv_tab.py
@@ -957,7 +957,16 @@ class SubstrateDef(QWidget):
                 self.new_substrate_count += 1
             else:
                 break
-            
+
+        self.new_substrate_named(subname)
+
+    def new_substrate_named(self, subname):
+        # Same split as cell_def_tab.new_cell_def_named(): add a substrate under a caller's
+        # name rather than the next "substrateNN". Callers should come through here rather
+        # than write the <variable> themselves -- the fan-out below seeds secretion and
+        # chemotactic sensitivity on *every* cell def, and cell_def_tab.fill_xml() raises on
+        # any that were missed.
+
         # Make a new substrate (that's a copy of the currently selected one)
         # self.param_d[subname] = self.param_d[self.current_substrate].copy()  #rwh - "copy()" is critical
 

--- a/bin/physicell_xml_defaults.py
+++ b/bin/physicell_xml_defaults.py
@@ -1,0 +1,352 @@
+"""
+physicell_xml_defaults.py - Studio's canonical defaults for a PhysiCell config (.xml).
+
+The nine fragments below are config/template.xml's non-cell-definition sections, hardcoded
+rather than read: template.xml is a config the user can open and save over, so it is not
+something to build a new document on. Keep them matching it by hand. They match today
+except <initial_conditions>, which is enabled here and disabled there -- callers that do
+not want a .csv loaded must turn it off themselves.
+
+XML_DEFAULT_SECTIONS maps a top-level config section name to its *children* as a raw
+XML fragment (no wrapper element). SECTION_ORDER is PhysiCell's document order;
+<cell_definitions> is inserted after "microenvironment_setup" by whoever assembles a
+document, since its content is not a default.
+
+default_phenotype() is the other half: config/template.xml's "default" cell definition,
+read once and used to fill in whatever a cell definition arrived without. CELL_DEF_SPEC
+says which sections that means.
+
+Authors:
+Dr. Daniel Bergman
+Rf. Credits.md
+"""
+
+import copy
+import os
+import xml.etree.ElementTree as ET
+
+
+XML_DEFAULT_SECTIONS = {
+
+    "domain": """
+            <x_min>-500</x_min>
+            <x_max>500</x_max>
+            <y_min>-500</y_min>
+            <y_max>500</y_max>
+            <z_min>-10</z_min>
+            <z_max>10</z_max>
+            <dx>20</dx>
+            <dy>20</dy>
+            <dz>20</dz>
+            <use_2D>true</use_2D>
+    """,
+
+    "overall": """
+            <max_time units="min">7200</max_time>
+            <time_units>min</time_units>
+            <space_units>micron</space_units>
+            <dt_diffusion units="min">0.01</dt_diffusion>
+            <dt_mechanics units="min">0.1</dt_mechanics>
+            <dt_phenotype units="min">6</dt_phenotype>
+    """,
+
+    "parallel": """
+            <omp_num_threads>4</omp_num_threads>
+    """,
+
+    "save":
+      """
+            <folder>output</folder>
+            <full_data>
+                <interval units="min">60</interval>
+                <enable>true</enable>
+            </full_data>
+            <SVG>
+                <interval units="min">60</interval>
+                <enable>true</enable>
+                <plot_substrate enabled="false" limits="false">
+                    <substrate>substrate</substrate>
+                    <min_conc />
+                    <max_conc />
+                </plot_substrate>
+            </SVG>
+            <legacy_data>
+                <enable>false</enable>
+            </legacy_data>
+    """,
+
+    "options": """
+            <legacy_random_points_on_sphere_in_divide>false</legacy_random_points_on_sphere_in_divide>
+            <virtual_wall_at_domain_edge>true</virtual_wall_at_domain_edge>
+            <disable_automated_spring_adhesions>false</disable_automated_spring_adhesions>
+            <random_seed>0</random_seed>
+        """,
+        
+    "microenvironment_setup":"""
+            <variable name="substrate" units="dimensionless" ID="0">
+                <physical_parameter_set>
+                    <diffusion_coefficient units="micron^2/min">100000.0</diffusion_coefficient>
+                    <decay_rate units="1/min">10</decay_rate>
+                </physical_parameter_set>
+                <initial_condition units="mmHg">0</initial_condition>
+                <Dirichlet_boundary_condition units="mmHg" enabled="False">0</Dirichlet_boundary_condition>
+                <Dirichlet_options>
+                    <boundary_value ID="xmin" enabled="False">0</boundary_value>
+                    <boundary_value ID="xmax" enabled="False">0</boundary_value>
+                    <boundary_value ID="ymin" enabled="False">0</boundary_value>
+                    <boundary_value ID="ymax" enabled="False">0</boundary_value>
+                    <boundary_value ID="zmin" enabled="False">0</boundary_value>
+                    <boundary_value ID="zmax" enabled="False">0</boundary_value>
+                </Dirichlet_options>
+            </variable>
+            <options>
+                <calculate_gradients>true</calculate_gradients>
+                <track_internalized_substrates_in_each_agent>true</track_internalized_substrates_in_each_agent>
+                <initial_condition type="matlab" enabled="false">
+                    <filename>./config/initial.mat</filename>
+                </initial_condition>
+                <dirichlet_nodes type="matlab" enabled="false">
+                    <filename>./config/dirichlet.mat</filename>
+                </dirichlet_nodes>
+            </options>
+        """,
+
+    "initial_conditions": """
+            <cell_positions type="csv" enabled="true">
+                <folder>./config</folder>
+                <filename>cells.csv</filename>
+            </cell_positions>
+    """,
+
+    "cell_rules": """
+            <rulesets>
+                <ruleset protocol="CBHG" version="3.0" format="csv" enabled="false">
+                    <folder>./config</folder>
+                    <filename>rules0.csv</filename>
+                </ruleset>
+            </rulesets>
+            <settings />
+    """,
+
+    "user_parameters": """
+            <number_of_cells type="int" units="none" description="initial number of cells (for each cell type)">5</number_of_cells>
+    """
+}
+
+
+SECTION_ORDER = tuple(XML_DEFAULT_SECTIONS.keys())
+
+# Where <cell_definitions> belongs relative to SECTION_ORDER. PhysiCell finds sections by
+# name so order is cosmetic to the simulator, but Studio's own configs put it here and a
+# diff against them should be about content, not layout.
+CELL_DEFINITIONS_AFTER = "microenvironment_setup"
+
+
+
+
+# ---------------------------------------------------------------------------
+# What a <cell_definition> must contain
+# ---------------------------------------------------------------------------
+
+# populate_tree_cell_defs.validate_cell_defs() requires these and sys.exit(-1)s when one
+# is absent (unless skip_validate); handle_parse_error() -> sys.exit(-1) is the except
+# handler for most of them. A cell_definition missing one does not merely fail to load,
+# it takes Studio down.
+REQUIRED_PHENOTYPE_SECTIONS = ("cycle", "death", "volume", "mechanics", "motility", "secretion")
+
+# The rest of what Studio's own configs always carry. Not required by validate_cell_defs(),
+# but populate_tree_cell_defs() falls back to hardcoded values when they are absent, which
+# silently discards whatever the source XML meant to say.
+OPTIONAL_PHENOTYPE_SECTIONS = ("cell_interactions", "cell_transformations", "cell_integrity")
+
+# Spec consumed by xml_validate.validate()/fill_missing(). Order is the order sections are
+# written back, so a filled-in section lands where Studio would have put it.
+CELL_DEF_SPEC = tuple(
+    {"path": "phenotype/" + name, "required": name in REQUIRED_PHENOTYPE_SECTIONS}
+    for name in REQUIRED_PHENOTYPE_SECTIONS + OPTIONAL_PHENOTYPE_SECTIONS
+) + (
+    # populate_tree_cell_defs() reads apoptosis one way or the other and sys.exit(-1)s if
+    # it finds neither. Carries a predicate, so xml_validate reports it but cannot fill it;
+    # filling "phenotype/death" above brings a complete model and clears this too.
+    {
+        "path": "phenotype/death/model[@name='apoptosis']",
+        "required": True,
+        "any_of": ("phase_durations", "phase_transition_rates"),
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# Default <phenotype>, read from the config Studio ships
+# ---------------------------------------------------------------------------
+
+# Last resort if template.xml is missing or unparseable. This is a copy of that file's
+# "default" phenotype rather than a shorter stand-in, because "complete" here means every
+# field, not every section: populate_tree_cell_defs reads most of them without checking they
+# are there, so an empty <volume/> is not a repair, it is a sys.exit(-1) on the next load.
+#
+# Nothing compares this against config/template.xml. When that file's default cell
+# definition gains a field, add it here by hand or the fallback silently drops it.
+_FALLBACK_PHENOTYPE = """
+    <phenotype>
+        <cycle code="6" name="Flow cytometry model (separated)">
+            <phase_durations units="min">
+                <duration index="0" fixed_duration="false">300.</duration>
+                <duration index="1" fixed_duration="true">480.</duration>
+                <duration index="2" fixed_duration="true">240.</duration>
+                <duration index="3" fixed_duration="true">60.</duration>
+            </phase_durations>
+        </cycle>
+        <death>
+            <model code="100" name="apoptosis">
+                <death_rate units="1/min">5.31667e-05</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">516</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+            <model code="101" name="necrosis">
+                <death_rate units="1/min">0.0</death_rate>
+                <phase_durations units="min">
+                    <duration index="0" fixed_duration="true">0</duration>
+                    <duration index="1" fixed_duration="true">86400</duration>
+                </phase_durations>
+                <parameters>
+                    <unlysed_fluid_change_rate units="1/min">1.11667e-2</unlysed_fluid_change_rate>
+                    <lysed_fluid_change_rate units="1/min">8.33333e-4</lysed_fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">5.33333e-5</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">2.16667e-3</nuclear_biomass_change_rate>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </parameters>
+            </model>
+        </death>
+        <volume>
+            <total units="micron^3">2494</total>
+            <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+            <nuclear units="micron^3">540</nuclear>
+            <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+            <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+            <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+            <calcified_fraction units="dimensionless">0</calcified_fraction>
+            <calcification_rate units="1/min">0</calcification_rate>
+            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+        </volume>
+        <mechanics>
+            <cell_cell_adhesion_strength units="micron/min">0.4</cell_cell_adhesion_strength>
+            <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+            <relative_maximum_adhesion_distance units="dimensionless">1.25</relative_maximum_adhesion_distance>
+            <cell_adhesion_affinities>
+                <cell_adhesion_affinity name="default">1</cell_adhesion_affinity>
+            </cell_adhesion_affinities>
+            <options>
+                <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+            </options>
+            <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+            <attachment_rate units="1/min">0.0</attachment_rate>
+            <detachment_rate units="1/min">0.0</detachment_rate>
+            <maximum_number_of_attachments>12</maximum_number_of_attachments>
+        </mechanics>
+        <motility>
+            <speed units="micron/min">1</speed>
+            <persistence_time units="min">5</persistence_time>
+            <migration_bias units="dimensionless">.5</migration_bias>
+            <options>
+                <enabled>false</enabled>
+                <use_2D>true</use_2D>
+                <chemotaxis>
+                    <enabled>false</enabled>
+                    <substrate>substrate</substrate>
+                    <direction>1</direction>
+                </chemotaxis>
+                <advanced_chemotaxis>
+                    <enabled>false</enabled>
+                    <normalize_each_gradient>false</normalize_each_gradient>
+                    <chemotactic_sensitivities>
+                        <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
+                    </chemotactic_sensitivities>
+                </advanced_chemotaxis>
+            </options>
+        </motility>
+        <secretion>
+            <substrate name="substrate">
+                <secretion_rate units="1/min">0</secretion_rate>
+                <secretion_target units="substrate density">1</secretion_target>
+                <uptake_rate units="1/min">0</uptake_rate>
+                <net_export_rate units="total substrate/min">0</net_export_rate>
+            </substrate>
+        </secretion>
+        <cell_interactions>
+            <apoptotic_phagocytosis_rate units="1/min">0.0</apoptotic_phagocytosis_rate>
+            <necrotic_phagocytosis_rate units="1/min">0.0</necrotic_phagocytosis_rate>
+            <other_dead_phagocytosis_rate units="1/min">0.0</other_dead_phagocytosis_rate>
+            <live_phagocytosis_rates>
+                <phagocytosis_rate name="default" units="1/min">0</phagocytosis_rate>
+            </live_phagocytosis_rates>
+            <attack_rates>
+                <attack_rate name="default" units="1/min">0</attack_rate>
+            </attack_rates>
+            <attack_damage_rate units="1/min">1</attack_damage_rate>
+            <attack_duration units="min">0.1</attack_duration>
+            <fusion_rates>
+                <fusion_rate name="default" units="1/min">0</fusion_rate>
+            </fusion_rates>
+        </cell_interactions>
+        <cell_transformations>
+            <transformation_rates>
+                <transformation_rate name="default" units="1/min">0</transformation_rate>
+            </transformation_rates>
+        </cell_transformations>
+        <cell_integrity>
+            <damage_rate units="1/min">0.0</damage_rate>
+            <damage_repair_rate units="1/min">0.0</damage_repair_rate>
+        </cell_integrity>
+    </phenotype>
+"""
+
+_default_phenotype_cache = {}
+
+
+def default_phenotype(nanohub_flag=False, data_dir=None):
+    """A deep copy of the <phenotype> from template.xml's "default" cell definition.
+
+    The source for filling in sections a cell definition arrived without, so it has to be
+    complete field by field, not merely section by section; _FALLBACK_PHENOTYPE stands in
+    when template.xml is missing or unparseable.
+    """
+    key = (bool(nanohub_flag), data_dir)
+    if key in _default_phenotype_cache:
+        return copy.deepcopy(_default_phenotype_cache[key])
+
+    if data_dir:
+        path = os.path.join(data_dir, "template.xml")
+    else:
+        # Mirrors studio.py's split: nanoHUB reads from data/, everyone else from config/.
+        path = os.path.join("data" if nanohub_flag else "config", "template.xml")
+
+    pheno = None
+    try:
+        root = ET.parse(path).getroot()
+        for cell_def in root.findall(".//cell_definitions/cell_definition"):
+            if cell_def.attrib.get("name") == "default":
+                pheno = cell_def.find("phenotype")
+                break
+        if pheno is None:  # no "default" in this template; any complete one will do
+            first = root.find(".//cell_definitions/cell_definition/phenotype")
+            pheno = first
+    except (OSError, ET.ParseError):
+        pheno = None
+
+    if pheno is None:
+        pheno = ET.fromstring(_FALLBACK_PHENOTYPE)
+
+    _default_phenotype_cache[key] = pheno
+    return copy.deepcopy(pheno)

--- a/bin/rules_tab.py
+++ b/bin/rules_tab.py
@@ -31,6 +31,7 @@ from multivariate_rules import Window_plot_rules
 # from studio_classes import ExtendedCombo, HoverWarning, QVLine, QLineEdit_custom, HoverQuestion
 from studio_classes import ExtendedCombo, QLabelSeparator, QLineEdit_custom, QVLine, QCheckBox_custom, QRadioButton_custom, HoverWarning, HoverQuestion, StudioTab
 from studio_functions import show_studio_warning_window
+import rules_tokens
 
 class RulesPlotWindow(QWidget):
     def __init__(self):
@@ -838,6 +839,15 @@ class Rules(StudioTab):
         if len(btokens) == 0:
             return
 
+        if key0 not in self.xml_creator.celldef_tab.param_d:
+            # Nearly every branch below indexes param_d[key0] and only one of them is guarded,
+            # so an unknown cell type here takes Studio down with a KeyError. Two ways to get
+            # one: clear_comboboxes() empties the cell type combobox before the behavior one,
+            # so the change callback runs with "" while the previous behavior is still
+            # selected; and the rules table can name a cell type this model does not define.
+            self.base_val = '??'    # what the callers already expect when it cannot be read
+            return
+
         base_val = '??'
         if btokens[0] in ["cycle", "exit"]:
             cycle_model_idx = self.xml_creator.celldef_tab.param_d[key0]['cycle_choice_idx']
@@ -927,7 +937,7 @@ class Rules(StudioTab):
                 print("--- handling phagocytose other dead cell")
                 base_val = self.xml_creator.celldef_tab.param_d[key0]['other_dead_phagocytosis_rate']
             else:
-                cell_type = behavior[12:]   # length of "phagocytose" 
+                cell_type = rules_tokens.extract_cell_type(behavior)
                 print("      cell_type (for phagocytose)=",cell_type)
                 base_val = self.xml_creator.celldef_tab.param_d[key0]['live_phagocytosis_rate'][cell_type]
         elif behavior == "attack damage rate":
@@ -935,24 +945,24 @@ class Rules(StudioTab):
         elif behavior == "attack duration":
             base_val = self.xml_creator.celldef_tab.param_d[key0]["attack_duration"]
         elif btokens[0] == "attack":
-            cell_type = behavior[7:]
+            cell_type = rules_tokens.extract_cell_type(behavior)
             base_val = self.xml_creator.celldef_tab.param_d[key0]['attack_rate'][cell_type]
         elif behavior[0:len("fuse to")] == "fuse to":
-            cell_type = behavior[len("fuse to")+1:]
+            cell_type = rules_tokens.extract_cell_type(behavior)
             base_val = self.xml_creator.celldef_tab.param_d[key0]['fusion_rate'][cell_type]
         elif btokens[0] == "immunogenicity":
             base_val = '1.0'
         elif btokens[0] == "is_movable":
             base_val = '1.0'
         elif behavior[0:len("transform to")] == "transform to":
-            cell_type = behavior[len("transform to")+1:]
+            cell_type = rules_tokens.extract_cell_type(behavior)
             base_val = self.xml_creator.celldef_tab.param_d[key0]['transformation_rate'][cell_type]
         elif behavior == "damage rate":
             base_val = self.xml_creator.celldef_tab.param_d[key0]["damage_rate"]
         elif behavior == "damage repair rate":
             base_val = self.xml_creator.celldef_tab.param_d[key0]["damage_repair_rate"]
         elif "asymmetric" == behavior.split()[0]:
-            cell_type = behavior.split()[-1]
+            cell_type = rules_tokens.extract_cell_type(behavior)
             base_val = self.xml_creator.celldef_tab.param_d[key0]["asymmetric_division_probability"][cell_type]
         elif "custom:" in btokens[0]:
             custom_data_name = btokens[0].split(':')[-1] # return string after colon
@@ -2000,34 +2010,22 @@ class Rules(StudioTab):
 
         self.signal_combobox.setCurrentIndex(0)
 
+    def celltypes_and_custom_vars(self):
+        """Cell type names, and the custom data variables to build tokens from.
+
+        Custom data comes from a *single* cell def, as it always has: the variables are
+        meant to be the same across all of them, and a rule names one without saying whose.
+        """
+        cell_types = list(self.xml_creator.celldef_tab.param_d.keys())
+        custom_vars = []
+        if cell_types:
+            cell_def0 = cell_types[0]
+            custom_vars = list(self.xml_creator.celldef_tab.param_d[cell_def0]['custom_data'].keys())
+        return cell_types, custom_vars
+
     def create_signal_list(self):
-        signal_l = []
-        for s in self.substrates:
-            signal_l.append(s)
-        for s in self.substrates:
-            signal_l.append("intracellular " + s)
-        for s in self.substrates:
-            signal_l.append(s + " gradient")
-
-        signal_l += ["pressure","volume"]
-
-        # print("       self.xml_creator.celldef_tab.param_d.keys()= ",self.xml_creator.celldef_tab.param_d.keys())
-        for ct in self.xml_creator.celldef_tab.param_d.keys():
-            signal_l.append("contact with " + ct)
-
-        # special
-        signal_l += ["contact with live cell", "contact with dead cell", 
-                     "contact with apoptotic cell", "contact with necrotic cell", 
-                     "contact with BM", "damage","dead", "attacking",
-                     "total attack time", "damage delivered", "time", "apoptotic", "necrotic"]
-
-        # append all custom data (but *only* for a single cell_def!)
-        cell_def0 = list(self.xml_creator.celldef_tab.param_d.keys())[0]
-        for custom_var in list(self.xml_creator.celldef_tab.param_d[cell_def0]['custom_data'].keys()):
-            signal_name = "custom:" + custom_var
-            signal_l.append(signal_name)
-
-        return signal_l
+        cell_types, custom_vars = self.celltypes_and_custom_vars()
+        return rules_tokens.build_signal_list(self.substrates, cell_types, custom_vars)
 
     #-----------------------------------------------------------
     def fill_responses_widget(self):
@@ -2043,50 +2041,8 @@ class Rules(StudioTab):
         self.xml_creator.celldef_tab.par_dist_fill_responses_widget(self.response_l + ["Volume"]) # everything else is lowercase, but this can stand out because it's not a true behavior, but rather the unique non-behavior that can be set by ICs
 
     def create_response_list(self):
-        # TODO: figure out how best to organize these responses
-        response_l = []
-        for s in self.substrates:
-            response_l.append(s + " secretion")
-        for s in self.substrates:
-            response_l.append(s + " secretion target")
-        for s in self.substrates:
-            response_l.append(s + " uptake")
-        for s in self.substrates:
-            response_l.append(s + " export")
-        response_l.append("cycle entry")
-        response_l.append("attack damage rate")
-        response_l.append("attack duration")
-        response_l.append("damage rate")
-        response_l.append("damage repair rate")
-        for idx in range(6):  # TODO: hardwired
-            response_l.append("exit from cycle phase " + str(idx))
-
-        response_l += ["apoptosis","necrosis","migration speed","migration bias","migration persistence time"]
-
-        for s in self.substrates:
-            response_l.append("chemotactic response to " + s)
-
-        response_l += ["cell-cell adhesion", "cell-cell adhesion elastic constant"]
-
-        for ct in self.xml_creator.celldef_tab.param_d.keys():
-            response_l.append("adhesive affinity to " + ct)
-
-        # special
-        response_l += ["relative maximum adhesion distance","cell-cell repulsion","cell-BM adhesion","cell-BM repulsion","phagocytose apoptotic cell","phagocytose necrotic cell","phagocytose other dead cell"]
-
-        for verb in ["phagocytose ","attack ","fuse to ","transform to ","immunogenicity to ","asymmetric division to "]:  # verb
-            for ct in self.xml_creator.celldef_tab.param_d.keys():
-                response_l.append(verb + ct)
-
-        # more special
-        response_l += ["is_movable","cell attachment rate","cell detachment rate","maximum number of cell attachments"]
-
-        # append all custom data (but *only* for a single cell_def!)
-        cell_def0 = list(self.xml_creator.celldef_tab.param_d.keys())[0]
-        for custom_var in self.xml_creator.celldef_tab.param_d[cell_def0]['custom_data'].keys():
-            response_name = "custom:" + custom_var
-            response_l.append(response_name)
-        return response_l
+        cell_types, custom_vars = self.celltypes_and_custom_vars()
+        return rules_tokens.build_behavior_list(self.substrates, cell_types, custom_vars)
 
     #-----------------------------------------------------------
     def fill_gui(self):

--- a/bin/rules_tokens.py
+++ b/bin/rules_tokens.py
@@ -1,0 +1,180 @@
+"""
+rules_tokens.py - the grammar of PhysiCell rule signals and behaviors.
+
+A rule is "<cell type>, <signal>, <direction>, <behavior>, ...". Signals and behaviors are
+strings, and many of them carry a substrate or a cell type *inside* the string --
+"contact with tumor", "transform to macrophage", "oxygen secretion". This module is the one
+place that grammar is written down: rules_tab.create_signal_list()/create_response_list()
+build the vocabularies from the recipes below, and extract_cell_type() reads a name back out
+of a token.
+
+"Behavior" throughout, not "response": the direction -- "increases", "decreases" -- is the
+response, and the behavior is what it acts on. rules_tab's create_response_list() and
+response_combobox name the same vocabulary the other way.
+
+This module states it once:
+
+    build_signal_list() / build_behavior_list()   produce the two vocabularies
+    extract_cell_type(token)                      recovers a cell type from one token
+
+Recipe order is combobox order: reordering a recipe, or a run within one, reorders the
+signal and behavior dropdowns users see.
+
+Beware RESERVED. Several fixed tokens look like parameterized ones -- "contact with dead
+cell" against "contact with {}", "attack duration" against "attack {}" -- so
+extract_cell_type() rules them out first, or it reports cell types named "dead cell" and
+"duration".
+
+Authors:
+Dr. Daniel Bergman
+Rf. Credits.md
+"""
+
+NUM_CYCLE_PHASES = 6  # rules_tab.create_reserved_words() hardwires the same 6
+
+# Recipe item kinds. Each produces a contiguous run of tokens; the order of the runs, and
+# the order within them, is the order the comboboxes show.
+_SUBS = "subs"        # one token per substrate, from a template
+_CTS = "cts"          # one token per cell type, from a template
+_LITS = "lits"        # fixed tokens
+_PHASES = "phases"    # one token per cycle phase index
+_CUSTOM = "custom"    # one token per custom-data variable
+
+SIGNAL_RECIPE = (
+    (_SUBS, "{}"),
+    (_SUBS, "intracellular {}"),
+    (_SUBS, "{} gradient"),
+    (_LITS, ("pressure", "volume")),
+    (_CTS, "contact with {}"),
+    (_LITS, (
+        "contact with live cell", "contact with dead cell",
+        "contact with apoptotic cell", "contact with necrotic cell",
+        "contact with BM", "damage", "dead", "attacking",
+        "total attack time", "damage delivered", "time", "apoptotic", "necrotic",
+    )),
+    (_CUSTOM, "custom:{}"),
+)
+
+BEHAVIOR_RECIPE = (
+    (_SUBS, "{} secretion"),
+    (_SUBS, "{} secretion target"),
+    (_SUBS, "{} uptake"),
+    (_SUBS, "{} export"),
+    (_LITS, (
+        "cycle entry", "attack damage rate", "attack duration",
+        "damage rate", "damage repair rate",
+    )),
+    (_PHASES, "exit from cycle phase {}"),
+    (_LITS, (
+        "apoptosis", "necrosis",
+        "migration speed", "migration bias", "migration persistence time",
+    )),
+    (_SUBS, "chemotactic response to {}"),
+    (_LITS, ("cell-cell adhesion", "cell-cell adhesion elastic constant")),
+    (_CTS, "adhesive affinity to {}"),
+    (_LITS, (
+        "relative maximum adhesion distance", "cell-cell repulsion",
+        "cell-BM adhesion", "cell-BM repulsion",
+        "phagocytose apoptotic cell", "phagocytose necrotic cell",
+        "phagocytose other dead cell",
+    )),
+    (_CTS, "phagocytose {}"),
+    (_CTS, "attack {}"),
+    (_CTS, "fuse to {}"),
+    (_CTS, "transform to {}"),
+    (_CTS, "immunogenicity to {}"),
+    (_CTS, "asymmetric division to {}"),
+    (_LITS, (
+        "is_movable", "cell attachment rate", "cell detachment rate",
+        "maximum number of cell attachments",
+    )),
+    (_CUSTOM, "custom:{}"),
+)
+
+
+def _literals(recipe):
+    out = []
+    for kind, payload in recipe:
+        if kind == _LITS:
+            out.extend(payload)
+        elif kind == _PHASES:
+            out.extend(payload.format(i) for i in range(NUM_CYCLE_PHASES))
+    return out
+
+
+def _templates(item_kind):
+    """The placeholder-carrying templates of one kind, taken from the recipes.
+
+    Derived rather than listed again: extract_cell_type() has to work on exactly the strings
+    build_signal_list()/build_behavior_list() produce, and a second hand-written copy is
+    free to drift out of step with them.
+    """
+    found = []
+    for recipe in (SIGNAL_RECIPE, BEHAVIOR_RECIPE):
+        for kind, payload in recipe:
+            if kind == item_kind and payload not in found:
+                found.append(payload)
+    return tuple(found)
+
+
+CELL_TYPE_TEMPLATES = _templates(_CTS)
+SUBSTRATE_TEMPLATES = _templates(_SUBS)
+
+# Every fixed token in either vocabulary. extract_cell_type() rejects these before parsing,
+# which is what stops "attack damage rate" from yielding a cell type named "damage rate".
+#
+# Shared across both rather than split by vocabulary, because the two do not overlap: no
+# signal literal is parseable by a behavior template or the reverse, so the union suppresses
+# nothing the halves would not. tests/test_rules_tokens.py holds that true.
+RESERVED = frozenset(_literals(SIGNAL_RECIPE) + _literals(BEHAVIOR_RECIPE))
+
+
+def _build(recipe, substrates, cell_types, custom_vars):
+    tokens = []
+    for kind, payload in recipe:
+        if kind == _SUBS:
+            tokens.extend(payload.format(s) for s in substrates)
+        elif kind == _CTS:
+            tokens.extend(payload.format(ct) for ct in cell_types)
+        elif kind == _LITS:
+            tokens.extend(payload)
+        elif kind == _PHASES:
+            tokens.extend(payload.format(i) for i in range(NUM_CYCLE_PHASES))
+        elif kind == _CUSTOM:
+            tokens.extend(payload.format(v) for v in custom_vars)
+    return tokens
+
+
+def build_signal_list(substrates, cell_types, custom_vars=()):
+    return _build(SIGNAL_RECIPE, substrates, cell_types, custom_vars)
+
+
+def build_behavior_list(substrates, cell_types, custom_vars=()):
+    return _build(BEHAVIOR_RECIPE, substrates, cell_types, custom_vars)
+
+
+def extract_cell_type(token):
+    """The cell type named inside *token*, or None if it names none.
+
+    Roster-free on purpose. scan_rules_for_missing_types() needs the names a rules file
+    mentions precisely so it can report the ones that are *not* in the model, and filtering
+    against the roster would drop exactly those. That works because every cell type template
+    carries a prefix -- "attack {}", "transform to {}" -- so a token anchors itself. The
+    substrate grammar cannot be read this way: a bare substrate name is a signal on its own,
+    so one of its templates is "{}", which matches anything.
+    """
+    if not token:
+        return None
+    token = token.strip()
+    if token in RESERVED:
+        return None
+
+    # Longest prefix first, so a short template cannot swallow a token a longer one matches.
+    for template in sorted(CELL_TYPE_TEMPLATES, key=len, reverse=True):
+        prefix, _, suffix = template.partition("{}")
+        if not token.startswith(prefix) or not token.endswith(suffix):
+            continue
+        name = token[len(prefix): len(token) - len(suffix) if suffix else None]
+        if name:
+            return name
+    return None

--- a/bin/studio.py
+++ b/bin/studio.py
@@ -1743,7 +1743,7 @@ def main():
 
         # "QMenu::separator { height: 1px; background: #808080; margin: 2px 8px; }"
     studio_app.setStyleSheet(
-        "QLineEdit { background-color: white };"
+        "QLineEdit { background-color: white }"
         "QMenu::separator { height: 9px; background: black; margin: 4px 8px; }"
     )
 

--- a/bin/xml_validate.py
+++ b/bin/xml_validate.py
@@ -1,0 +1,196 @@
+"""
+xml_validate.py - generic, spec-driven checking and repair of an ElementTree subtree.
+
+Nothing here knows about PhysiCell. A caller supplies a *spec* -- a sequence of entries
+describing the child paths an element is expected to have -- and gets back a list of
+Problems, or has the gaps filled in from a template element.
+
+get_text()/set_text() are the safe form of Studio's usual
+`self.xml_root.find(".//x_min").text` (config_tab.py:696), which raises AttributeError on a
+config that is merely incomplete. validate() reports which part of an element is wrong;
+populate_tree_cell_defs.validate_cell_defs() reports only that it is.
+
+Spec entry (a dict, so entries can grow fields without breaking callers):
+
+    path       "phenotype/cycle" -- slash-separated, relative to the element passed in.
+               May use ElementPath predicates ("death/model[@name='apoptosis']"), in which
+               case the entry is reported but not filled: create its parent instead.
+    required   True if its absence is an error rather than something to fill in.
+    attribs    optional; attribute names that must be present on the element.
+    any_of     optional; child tags, at least one of which must be present.
+
+Authors:
+Dr. Daniel Bergman
+Rf. Credits.md
+"""
+
+import copy
+import xml.etree.ElementTree as ET
+
+
+MISSING = "missing"
+EMPTY = "empty"
+BAD_ATTRIB = "bad_attrib"
+
+
+class Problem:
+    """One thing wrong with an element, located by path."""
+
+    __slots__ = ("path", "kind", "detail", "required")
+
+    def __init__(self, path, kind, detail="", required=True):
+        self.path = path
+        self.kind = kind
+        self.detail = detail
+        self.required = required
+
+    def __repr__(self):
+        return "Problem(%r, %r, %r, required=%r)" % (self.path, self.kind, self.detail, self.required)
+
+    def __str__(self):
+        if self.detail:
+            return "%s: %s (%s)" % (self.path, self.kind, self.detail)
+        return "%s: %s" % (self.path, self.kind)
+
+
+def _has_predicate(path):
+    return "[" in path
+
+
+def validate(elm, spec):
+    """Check *elm* against *spec*. Returns a list of Problems, empty if it is clean."""
+    problems = []
+    if elm is None:
+        return [Problem("", MISSING, "no element to validate")]
+
+    for entry in spec:
+        path = entry["path"]
+        required = entry.get("required", True)
+        found = elm.find(path)
+
+        if found is None:
+            problems.append(Problem(path, MISSING, required=required))
+            continue
+
+        for name in entry.get("attribs", ()):
+            if name not in found.attrib:
+                problems.append(
+                    Problem(path, BAD_ATTRIB, "missing @%s" % name, required=required)
+                )
+
+        alternatives = entry.get("any_of", ())
+        if alternatives and not any(found.find(alt) is not None for alt in alternatives):
+            problems.append(
+                Problem(
+                    path,
+                    EMPTY,
+                    "needs one of: %s" % ", ".join(alternatives),
+                    required=required,
+                )
+            )
+
+    return problems
+
+
+def _spec_order(spec, parent_path):
+    """Tags the spec expects directly under *parent_path*, in spec order."""
+    order = []
+    for entry in spec:
+        path = entry["path"]
+        head, _, tail = path.rpartition("/")
+        if head == parent_path and not _has_predicate(tail):
+            order.append(tail)
+    return order
+
+
+def fill_missing(elm, spec, defaults_elm):
+    """Copy any spec path absent from *elm* out of *defaults_elm*.
+
+    Returns the list of paths filled in. Each is inserted at the position the spec implies
+    among its siblings, so a repaired element keeps the section order the spec declares
+    rather than collecting additions at the end.
+
+    Entries whose path carries a predicate are skipped -- there is no general way to
+    synthesize `model[@name='apoptosis']` -- so fill their parent instead and re-validate.
+    """
+    filled = []
+    if elm is None or defaults_elm is None:
+        return filled
+
+    for entry in spec:
+        path = entry["path"]
+        if _has_predicate(path) or elm.find(path) is not None:
+            continue
+
+        source = defaults_elm.find(path)
+        if source is None:
+            continue
+
+        parent_path, _, tag = path.rpartition("/")
+        parent = find_or_create(elm, parent_path) if parent_path else elm
+        if parent is None:
+            continue
+
+        # Land after every sibling the spec puts ahead of this one. The children already
+        # present need not be in spec order, so take the highest such position, not the
+        # last one looked at.
+        order = _spec_order(spec, parent_path)
+        index = 0
+        if tag in order:
+            children = list(parent)
+            for earlier in order[: order.index(tag)]:
+                existing = parent.find(earlier)
+                if existing is not None:
+                    index = max(index, children.index(existing) + 1)
+
+        parent.insert(index, copy.deepcopy(source))
+        filled.append(path)
+
+    return filled
+
+
+def find_or_create(elm, path):
+    """find(), creating any missing elements along the way. Predicates are not supported.
+
+    *path* is a chain of direct-child tags: "save/SVG/plot_substrate". Studio writes most
+    of its paths as descendant searches -- ".//SVG//plot_substrate" -- and those are NOT
+    interchangeable here: each "//" leaves an empty segment, which is skipped, so the tags
+    around it are looked up and created as direct children. Handing this function
+    ".//SVG//plot_substrate" on a root that keeps <SVG> under <save> appends a second,
+    top-level <SVG><plot_substrate/> and returns that. find() the parent first, then
+    create beneath it.
+    """
+    if elm is None:
+        return None
+    if not path:
+        return elm
+    if _has_predicate(path):
+        return elm.find(path)
+
+    current = elm
+    for tag in path.split("/"):
+        if not tag or tag == ".":
+            continue
+        found = current.find(tag)
+        if found is None:
+            found = ET.SubElement(current, tag)
+        current = found
+    return current
+
+
+def get_text(elm, path, default=None):
+    """Text at *path*, or *default* if the element is absent or has no text."""
+    if elm is None:
+        return default
+    found = elm.find(path)
+    if found is None or found.text is None:
+        return default
+    return found.text
+
+
+def set_text(elm, path, value):
+    """Set the text at *path*, creating the element (and its parents) if needed."""
+    found = find_or_create(elm, path)
+    if found is not None:
+        found.text = str(value)
+    return found

--- a/doc/BIWT.md
+++ b/doc/BIWT.md
@@ -19,15 +19,15 @@ Install `biwt` into Studio's conda environment and launch Studio with `--biwt`:
 ```bash
 conda env create -f environment.yml   # creates the "studio" environment
 conda activate studio
-pip install biwt                       # no extras -- see the warning below
-python bin/studio.py --biwt            # within the activated env
+pip install 'biwt>=0.6.0'             # no extras -- see the warning below
+python bin/studio.py --biwt           # within the activated env
 ```
 
-> **Install `biwt` without extras here.** Studio's conda environment already provides
-> PyQt5, matplotlib, and anndata, so `biwt[gui]`, `biwt[anndata]`, and `biwt[all]` are
-> unnecessary — and `biwt[gui]` is actively harmful, because it installs pip's own PyQt5
-> on top of conda's and breaks Studio. (`biwt[seurat]` is the one exception: it is needed
-> for `.rds` input and does not touch PyQt5 — see below.)
+> **Install `biwt` without extras here.** This environment already has everything the
+> extras would add: PyQt5 from pip, matplotlib and anndata from conda (see
+> `environment.yml`). So `biwt[gui]`, `biwt[anndata]`, and `biwt[all]` buy nothing, and
+> `biwt[gui]` can re-resolve PyQt5 to a different build than the one Studio is running on.
+> (`biwt[seurat]` is the one exception: it is needed for `.rds` input — see below.)
 
 If `biwt` is not installed, Studio falls back to the legacy built-in BIWT tab.
 
@@ -50,8 +50,7 @@ Two Studio-specific substitutions when following those pages: the environment th
 `<env>` is `studio`, and where they launch the host application, run
 `python bin/studio.py --biwt`.
 
-If Studio dies with a segmentation fault when importing a `.rds`, that is the R / `rpy2`
-mismatch covered under Troubleshooting above — not a Studio bug.
+
 
 ## Using BIWT
 

--- a/tests/test_rules_tokens.py
+++ b/tests/test_rules_tokens.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""The invariants rules_tokens.extract_cell_type() quietly depends on.
+
+It parses a token by matching it against the cell type templates, after rejecting RESERVED --
+the fixed tokens that look parameterized ("attack duration" against "attack {}"). RESERVED is
+the union of both vocabularies' literals, which is only safe while no literal of one is
+matchable by the other's templates. Nothing enforces that; these tests do.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "bin"))
+
+import rules_tokens as rt
+
+
+CELL_TYPES = ["macrophage", "CD8+ T cell", "blood vessel", "tumor"]
+SUBSTRATES = ["oxygen", "resource", "pro-inflammatory"]
+
+
+def _cell_type_templates(recipe):
+    return tuple(payload for kind, payload in recipe if kind == rt._CTS)
+
+
+def _match(token, templates):
+    """What extract_cell_type() would pull out, ignoring RESERVED.
+
+    Duplicates its matching loop (rules_tokens.py, the sorted-by-length scan) so the tests
+    can ask what the templates match with RESERVED out of the way. Keep the two in step:
+    if they diverge, these tests pass while asserting nothing about the real function.
+    """
+    for template in sorted(templates, key=len, reverse=True):
+        prefix, _, suffix = template.partition("{}")
+        if token.startswith(prefix) and token.endswith(suffix):
+            name = token[len(prefix): len(token) - len(suffix) if suffix else None]
+            if name:
+                return name
+    return None
+
+
+def test_reserved_does_not_reach_across_vocabularies():
+    """No literal of one vocabulary is parseable by the other's cell type templates.
+
+    RESERVED merges both, so a collision here would mean a signal literal silently
+    suppressing a behaviour that names a cell type, or the reverse -- and the failure would
+    be a missing warning, not an error. Split RESERVED by vocabulary if this ever trips.
+    """
+    signal_literals = rt._literals(rt.SIGNAL_RECIPE)
+    behavior_literals = rt._literals(rt.BEHAVIOR_RECIPE)
+
+    for literals, others, label in (
+        (signal_literals, _cell_type_templates(rt.BEHAVIOR_RECIPE), "signal"),
+        (behavior_literals, _cell_type_templates(rt.SIGNAL_RECIPE), "behavior"),
+    ):
+        for literal in literals:
+            assert _match(literal, others) is None, (
+                "%s literal %r parses as a cell type under the other vocabulary's templates; "
+                "RESERVED can no longer be shared between the two" % (label, literal))
+
+
+def test_reserved_covers_every_literal_its_own_templates_would_mis_parse():
+    """The positive half: RESERVED has to hold the literals that do look parameterized."""
+    for recipe in (rt.SIGNAL_RECIPE, rt.BEHAVIOR_RECIPE):
+        own = _cell_type_templates(recipe)
+        for literal in rt._literals(recipe):
+            if _match(literal, own) is not None:
+                assert literal in rt.RESERVED, (
+                    "%r parses as a cell type but is not RESERVED" % literal)
+                assert rt.extract_cell_type(literal) is None
+
+
+def test_every_generated_cell_type_token_reads_back():
+    """Round trip: whatever the vocabularies build, extract_cell_type() recovers."""
+    signals = rt.build_signal_list(SUBSTRATES, CELL_TYPES)
+    behaviors = rt.build_behavior_list(SUBSTRATES, CELL_TYPES)
+
+    for recipe, tokens in ((rt.SIGNAL_RECIPE, signals), (rt.BEHAVIOR_RECIPE, behaviors)):
+        expected = {template.format(name): name
+                    for template in _cell_type_templates(recipe)
+                    for name in CELL_TYPES}
+        for token in tokens:
+            assert rt.extract_cell_type(token) == expected.get(token), token
+        assert expected, "recipe carries no cell type templates"
+
+
+def test_substrate_tokens_are_not_read_as_cell_types():
+    """A substrate name is a signal on its own, so its template is "{}" -- it matches anything.
+
+    extract_cell_type() only consults the cell type templates, all of which carry a prefix.
+    """
+    for substrate in SUBSTRATES:
+        for template in rt.SUBSTRATE_TEMPLATES:
+            token = template.format(substrate)
+            if _match(token, _cell_type_templates(rt.SIGNAL_RECIPE)
+                             + _cell_type_templates(rt.BEHAVIOR_RECIPE)) is None:
+                assert rt.extract_cell_type(token) is None, token
+
+
+def test_new_modules_import_without_the_biwt_package():
+    """Studio ships without `biwt` installed; the bridge modules must still import.
+
+    They name two things from it -- HOST_SOURCE and DomainSource -- behind try/except, and
+    the fallbacks have to carry the same values, or a Studio with the package and one
+    without would disagree about which template is "the host's".
+    """
+    import importlib
+
+    class Block:
+        def find_spec(self, name, path=None, target=None):
+            if name == "biwt" or name.startswith("biwt."):
+                raise ImportError("blocked by test")
+            return None
+
+    blocker = Block()
+    saved = {k: v for k, v in sys.modules.items()
+             if k.split(".")[0] in ("biwt", "biwt_bridge", "biwt_bridge_ui")}
+    for name in saved:
+        del sys.modules[name]
+    sys.meta_path.insert(0, blocker)
+    try:
+        bridge = importlib.import_module("biwt_bridge")
+        assert bridge.HOST_SOURCE == "<host>"
+        try:
+            ui = importlib.import_module("biwt_bridge_ui")
+        except ImportError:
+            return          # no PyQt5 in this environment; the pure half is what matters
+        assert ui._biwt_version() == ""
+        for value, label in (("host", "from Studio"), ("data", "from data"),
+                             ("user", "user-edited"), ("default", "BIWT default")):
+            assert ui._domain_source_label(value) == label, value
+    finally:
+        sys.meta_path.remove(blocker)
+        for name in [k for k in sys.modules
+                     if k.split(".")[0] in ("biwt", "biwt_bridge", "biwt_bridge_ui")]:
+            del sys.modules[name]
+        sys.modules.update(saved)


### PR DESCRIPTION
BIWT 0.5 stopped returning a whole `<PhysiCell_settings>` document. It now hands
back cell positions and `cell_templates = {cell type: (path, template name, content)}`,
where a path of `<host>` means "copy this model's own definition of that cell type".
Everything else in a config — domain, save, options, microenvironment, rules, user
parameters — becomes Studio's to own.

This adds that, plus a way to merge BIWT's cell types into the model already open
rather than only writing a new file.

## What the user sees

One dialog to decide where things go, one to report what happened. The first asks
only about the destination: every choice about a cell type was made inside BIWT, so
the rest is shown, not asked. Nothing is written until it is accepted, because the
completion callback is one-shot and Cancel discards the whole walkthrough.

Three destinations — merge into the open model, write a new config file, or keep only
the positions `.csv`. Each says something different about substrates, rules, the
domain and the initial conditions, and each of those claims is false for one of the
others, so they follow the selected destination rather than being stated once.

## New modules

| File | |
|---|---|
| `bin/biwt_bridge.py` | Reading BIWT's result, reconciling it against the model, assembling the XML. ElementTree and csv only — no Qt, so the rules are testable without a QApplication. |
| `bin/biwt_bridge_ui.py` | The two dialogs and the writes that follow. |
| `bin/physicell_xml_defaults.py` | The config sections Studio now owns, moved out of `BIWT_parameters/`. |
| `bin/xml_validate.py` | Spec-driven validate / fill-missing / None-safe accessors. No PhysiCell knowledge. |
| `bin/rules_tokens.py` | The signal and behavior token grammar, previously built by string concatenation in `rules_tab` and picked apart by open-coded prefix slicing. |

`BIWT_parameters/xml_defaults.py` becomes a shim rebuilding the identical dict for
the deprecated in-tree tab, which is otherwise untouched and still works.

## Three things in here are load-bearing, not tidy

All because of how a config is read back in:

- **IDs must come out 0..N-1.** With `auto number IDs when saved` unticked — its default,
  and nothing in `bin/` ever ticks it — `cell_def_tab.fill_xml()` walks
  `range(len(param_d))` and emits only the cell def whose ID equals `count`, so a gap or a
  duplicate silently drops a cell type from the file on the next save. BIWT 0.5 supplies no
  IDs (there is no `ID=` anywhere in the package), so Studio assigns all of them, and on a
  merge the injected definitions have to land in one contiguous run alongside the existing
  ones.
- **`<secretion>` must name exactly the model's substrates.** `fill_xml_secretion()`
  indexes `param_d[cdef]["secretion"][substrate]` from a dict filled *from the XML*, so
  a missing entry is a modal error per substrate per cell type, not a default.
- **A cell definition missing a phenotype section takes Studio down.**
  `validate_cell_defs()` and `handle_parse_error()` both end in `sys.exit(-1)`. Hence
  the repair pass, and hence the backup before any overwrite.

## Notable behavior

A cell definition copied out of this model names every substrate the model has, most
of them at zero — so choosing one host cell type carries that whole microenvironment
into a new config. That is deliberate: a rule, or a project's own C++, can tie a cell
type to a substrate whose XML rates are all `0`, and neither is visible from here. The
receipt names the substrates and the cell type that brought them.

A new config takes `<cell_rules>` from Studio's defaults like every other section, so
the open model's ruleset is not carried over. The dialog says so, with a count.

Studio does no cell-type name matching of its own beyond stripping whitespace.
Whatever the user called a type inside BIWT is what gets built.

## Also fixed here

`rules_tab.update_base_value_by_name()` indexes `param_d[key0]` in some thirty
branches with one of them guarded. Clearing the cell type combobox fires the change
callback with `""` while the behavior box still holds the previous selection, so a
reload with an `attack …` rule selected exits to the terminal with `KeyError: ''`.
Pre-existing, but the merge reload walks straight into it.

## Testing

A manual GUI checklist covering all three destinations, host templates, types left at
`(none)`, and PhysiCell actually accepting the output. Alongside it, probes that run
without standing up the app: the dialog's full claim-versus-destination matrix, the
resolve/repair passes being safe to run twice, and equivalence checks proving the
`xml_defaults` shim and the rebuilt signal/behavior lists are byte-identical to
`54e8ba6`.

Deliberately left for a separate change: `sys.exit(-1)` in `populate_tree_cell_defs`,
seeding `param_d[cd]["secretion"]` from `substrate_list`, and
`config_tab.fill_xml()`'s unguarded `cell_positions` dereference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

