### PR TITLE
Tie plot_svg bogus-coordinate test to the loaded domain

### DIFF
--- a/bin/vis_tab.py
+++ b/bin/vis_tab.py
@@ -510,14 +510,13 @@ class Vis(VisBase, QWidget):
                     rgba = [1,1,1,1.0]
                     rgba[0:3] = [x for x in rgb_tuple]
 
-                # test for bogus x,y locations (rwh TODO: use max of domain?)
-                too_large_val = 10000.
-                if (np.fabs(xval) > too_large_val):
+                # test for bogus x,y locations, i.e., outside the domain of the loaded output
+                if (xval < self.xmin) or (xval > self.xmax):
                     print("bogus xval=", xval)
                     break
                 yval = float(circle.attrib['cy'])
                 yval = yval/self.y_range * self.y_range + self.ymin
-                if (np.fabs(yval) > too_large_val):
+                if (yval < self.ymin) or (yval > self.ymax):
                     print("bogus yval=", yval)
                     break
 

--- a/bin/vis_tab_ecm.py
+++ b/bin/vis_tab_ecm.py
@@ -567,15 +567,14 @@ class Vis(VisBase, QWidget):
                     rgba = [1,1,1,1.0]
                     rgba[0:3] = [x for x in rgb_tuple]
 
-                # test for bogus x,y locations (rwh TODO: use max of domain?)
-                too_large_val = 10000.
-                if (np.fabs(xval) > too_large_val):
+                # test for bogus x,y locations, i.e., outside the domain of the loaded output
+                if (xval < self.xmin) or (xval > self.xmax):
                     print("bogus xval=", xval)
                     break
                 yval = float(circle.attrib['cy'])
                 # yval = (yval - self.svg_xmin)/self.svg_xrange * self.y_range + self.ymin
                 yval = yval/self.y_range * self.y_range + self.ymin
-                if (np.fabs(yval) > too_large_val):
+                if (yval < self.ymin) or (yval > self.ymax):
                     print("bogus yval=", yval)
                     break
 


### PR DESCRIPTION
### Problem

`plot_svg()` sanity-checked each cell's mapped coordinates against a hardcoded `too_large_val = 10000.`:

```python
# test for bogus x,y locations (rwh TODO: use max of domain?)
too_large_val = 10000.
if (np.fabs(xval) > too_large_val):
    print("bogus xval=", xval)
    break
```

Any cell farther than 10000 from the origin in x or y was silently dropped (and `break` skipped the rest of that cell's circles), so simulations with a domain larger than +/-10000 had legitimate cells cropped out of the SVG plot.

### Change

Test against the domain of the loaded output instead — `self.xmin`/`self.xmax`, `self.ymin`/`self.ymax` — which is the same frame of reference the SVG coords are mapped into on the line just above the test (`xval = xval/self.x_range * self.x_range + self.xmin`). In-domain cells therefore always pass by construction, whatever the domain size. This resolves the existing `rwh TODO: use max of domain?` note.

Applied in both copies of the function:
- `bin/vis_tab.py`
- `bin/vis_tab_ecm.py`

### Notes for review

- No tolerance/padding is added, so a cell whose center has left the domain entirely is now dropped where previously it was kept if within +/-10000. Such cells fall outside the default plot limits (`plot_xmin`/`plot_xmax` are the domain) so they were not visible anyway, but if you'd rather keep them for zoomed-out views, say so and I'll pad the test by a fraction of the domain extent.
- `examples/anim_svg.py` and `examples/anim_cells_tracks.py` carry the same hardcoded 10000, but those standalone scripts never read `initial.xml` (they take `axes_max` from the SVG width), so there's no loaded domain to tie to — left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)