### PR TITLE
Fix three memory retentions in the Plot tab

### DIFF
--- a/bin/vis_base.py
+++ b/bin/vis_base.py
@@ -354,7 +354,6 @@ class VisBase():
         self.bgcolor = [1,1,1,1]  # all 1.0 for white 
 
         self.discrete_variable_observed = set()
-        self.cell_scalar_updated = True
 
         self.cell_scalar_human2mcds_dict = {} # initialize here for vis_tab.py
 
@@ -1791,7 +1790,6 @@ class VisBase():
 
     def cell_scalar_combobox_changed_cb(self, idx):
         self.discrete_variable_observed = set()
-        self.cell_scalar_updated = True
         self.update_plots()
     
     #-------------------------------------
@@ -1865,6 +1863,7 @@ class VisBase():
             except:
                 pass
             self.cax2 = None
+            self.cbar2 = None   # its Axes is gone; do not draw into it again
 
     def cells_svg_mat_cb(self):
         # print("\n---------cells_svg_mat_cb(self)")
@@ -2575,9 +2574,10 @@ class VisBase():
             if self.cax2:
                 try:
                     self.cax2.remove()
-                    self.cax2 = None
                 except:
                     pass
+                self.cax2 = None
+                self.cbar2 = None   # its Axes is gone; do not draw into it again
             
         # print("\n>>> calling update_plots() from "+ inspect.stack()[0][3])
         self.update_plots()
@@ -3419,6 +3419,11 @@ class VisBase():
             msgBox.exec()
 
         self.current_svg_frame = original_frame  # Restore the original frame number
+
+        # pyplot's Gcf holds every figure until it is closed, and each `ims` entry is a full
+        # copy of the canvas framebuffer, so drop them both here.
+        ims.clear()
+        plt.close(fig)
 
     def cancel_movie_cb(self):
         self.cancel_movie = True

--- a/bin/vis_tab.py
+++ b/bin/vis_tab.py
@@ -657,9 +657,10 @@ class Vis(VisBase, QWidget):
         if self.cax2:
             try:
                 self.cax2.remove()
-                self.cax2 = None
             except:
                 pass
+            self.cax2 = None
+            self.cbar2 = None   # its Axes is gone; do not draw into it again
    
         self.ax0.set_title(self.title_str, fontsize=self.title_fontsize)
         self.ax0.set_xlim(self.plot_xmin, self.plot_xmax)
@@ -674,7 +675,7 @@ class Vis(VisBase, QWidget):
         boolean_colors = ["green", "red", "grey"]
         
         # Creating empty plots to add the legend
-        lp = lambda i: plt.plot([],color=boolean_colors[i], ms=np.sqrt(81), mec="none",
+        lp = lambda i: self.ax0.plot([],color=boolean_colors[i], ms=np.sqrt(81), mec="none",
                                 label="Feature {:g}".format(i), ls="", marker="o")[0]
         handles = [lp(i) for i in range(3)]
         try: # cautionary for out of date mpl versions, e.g., nanoHUB
@@ -830,14 +831,15 @@ class Vis(VisBase, QWidget):
             if self.cax2 is not None:
                 try:
                     self.cax2.remove()
-                    self.cax2 = None
                 except:
                     pass
+                self.cax2 = None
+                self.cbar2 = None   # its Axes is gone; do not draw into it again
             # Coloring the cells as it used to be
             cell_plot.set_clim(vmin=-0.5,vmax=len(self.discrete_variable)-0.5) 
             
             # Creating empty plots to add the legend
-            lp = lambda i: plt.plot([],color=cmaps.paint_clist[i], ms=np.sqrt(81), mec="none",
+            lp = lambda i: self.ax0.plot([],color=cmaps.paint_clist[i], ms=np.sqrt(81), mec="none",
                                     label="Feature {:g}".format(i), ls="", marker="o")[0]
             handles = [lp(self.discrete_variable.index(i)) for i in sorted(list(self.discrete_variable_observed)) if i in self.discrete_variable]
             try: # cautionary for out of date mpl versions, e.g., nanoHUB
@@ -849,16 +851,15 @@ class Vis(VisBase, QWidget):
             # If it's not there, we create it
             if self.cax2 is None:
                 self.cax2 = self.figure.add_subplot(self.gs[1,0])
-                # added 5/11/26 to fix toggling back to .mat after .svg
-                self.cbar2 = self.figure.colorbar(cell_plot, ticks=None, cax=self.cax2, orientation="horizontal")
-                self.cell_scalar_updated = False
+                self.cbar2 = None   # a new Axes needs its own Colorbar
+
             if self.cbar2 is None:
                 self.cbar2 = self.figure.colorbar(cell_plot, ticks=None, cax=self.cax2, orientation="horizontal")
-            elif self.cell_scalar_updated:
-                self.cbar2 = self.figure.colorbar(cell_plot, ticks=None, cax=self.cax2, orientation="horizontal")
-                self.cell_scalar_updated = False
-            else:  # called on continuous "Play" plots; range auto-updates
-                self.cbar2.update_normal(cell_plot)  # partial fix for memory leak
+            else:
+                # Never build a second Colorbar on a live cax2: each one chains itself onto the
+                # previous via cax2._axes_locator and pins that frame's cell PatchCollection forever.
+                # update_normal() picks up a new cmap and range just as well.
+                self.cbar2.update_normal(cell_plot)
 
             self.cbar2.ax.set_xlabel(cell_scalar_humanreadable_name, fontsize=self.cbar_label_fontsize)
             self.cbar2.ax.tick_params(labelsize=self.fontsize)


### PR DESCRIPTION
TL;DR: A small set of changes that improves management of matplotlib objects that resolves memory leaks.

## What

Three things reachable from the Plot tab retain matplotlib objects for the life of the process. Plain frame cycling is **not** one of them — that was measured and is flat.

Everything below was measured by driving the Studio headlessly (offscreen Qt) over real PhysiCell output, 1591 cells, sampling RSS and live-object counts via `gc` every 50 draws.

## 1. Stacked colorbars on a live `cax2` — `bin/vis_tab.py`

Every change of the cell-scalar combobox built a **new** `Colorbar` on the **existing** `cax2`. matplotlib's `_ColorbarAxesLocator.__init__` does `self._orig_locator = cbar.ax._axes_locator`, so each colorbar chains onto its predecessor, which holds its `mappable` — that frame's entire cell `PatchCollection`.

| 300 scalar changes | before | after |
|---|---|---|
| live `Colorbar` | 1 → **301** | 2, flat |
| live `PatchCollection` | 1 → **300** | 1, flat |
| `cax2.get_children()` | 13 → **611** | 13, flat |
| RSS | 523 → **950 MB** | 519 → 585 MB (plateaus) |

It also degraded rendering: `canvas.draw()` went **20 ms → 45 ms after 200 changes**, because every stale QuadMesh is re-rendered on every frame — so Play got progressively slower the more scalars you'd looked at.

`update_normal()` was verified to produce a **pixel-identical and tick-identical** colorbar to a freshly built one even when the colormap *and* the data range both change, so the rebuild branch wasn't buying anything.

> Worth noting for review: calling `self.cbar2.remove()` before rebuilding is *not* a viable alternative. `ax0.cla()` has already detached the previous mappable, so `Colorbar.remove()` hits `self.mappable.axes.get_position()` with `axes = None` and raises `AttributeError`.

`self.cell_scalar_updated` existed only to trigger that rebuild and had no other reader in the repo, so it's removed.

## 2. Legend handles built with `plt.plot()` — `bin/vis_tab.py`

```python
lp = lambda i: plt.plot([], color=cmaps.paint_clist[i], ...)[0]
```

`plt.plot` targets `plt.gcf().gca()`, not `self.ax0`. Nothing in the Studio ever re-activates the Vis figure, and `plt.close` appears nowhere in `bin/` — so once any other pyplot figure exists (cell-counts window, Make Movie, gradient-angle wheel, rules plot), every frame stranded one `Line2D` per cell type on a foreign axes that is never cleared.

Measured with the cell-counts window open, discrete scalar, 200 frames:

| | before | after |
|---|---|---|
| `plt.gca().lines` | 1 → **400** (2/frame) | 0, flat |
| live `Line2D` | 179 → **591** | 146 → 160, flat |

~10.5 KB traced per stranded line, so ~6 MB per 100 frames at 6 cell types. This is why the growth looked intermittent — it's gated behind one unrelated click. `self.ax0.plot()` keeps the handles on the axes `update_plots()` already clears; the legend renders identically (checked visually for `current_phase`).

## 3. Make Movie never released its figure — `bin/vis_base.py`

`plt.subplots()` registers the figure in pyplot's `Gcf`, which holds it until closed, and each `ims` entry is a full copy of the canvas framebuffer (~1.2 MB/frame at 640×480). Both are released when the movie finishes.

This one is code-read plus the `plt.close` grep, not measured end-to-end. One known gap: if `ani.save()` raises (e.g. ffmpeg failure), the cleanup is skipped. Wrapping the body in `try/finally` would close that, at the cost of reindenting the whole function — happy to do it if you'd prefer.

## Also: drop `self.cbar2` wherever `self.cax2` is removed

Four sites — `vis_base.py` `disable_cell_scalar_widgets()` and `cells_toggle_cb()`, `vis_tab.py` `plot_cell_physiboss()` and the discrete-scalar branch. This makes explicit the invariant that c3663d8 restored by other means when it fixed the white `.svg` → `.mat` colorbar: a `Colorbar` must never outlive its `Axes`.

For the record, the white-colorbar bug itself does **not** leak — toggling `.svg` ↔ `.mat` 200× is flat on both object counts and RSS, because removing the axes takes the colorbar's artists with it.

## Verification

- `.svg` ↔ `.mat` toggling, frame cycling (800 draws), discrete and continuous cell scalars: all still render correctly, no white colorbar, object counts flat.
- Both leaks confirmed fixed by re-running the same measurements above.
- `tests/test_rules_tokens.py`, `tests/test_dfba_serialization.py`: 7 passed.
- `tests/test_studio.py` could **not** be run here — `pytest-qt` isn't installed in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
