### PR TITLE
Map .svg cell coords with the loaded output's own domain

### DIFF
--- a/bin/vis_base.py
+++ b/bin/vis_base.py
@@ -543,6 +543,15 @@ class VisBase():
         self.xdel = 20
         self.z_range = self.zmax - self.zmin
 
+        # Domain of the *loaded output*, read from its initial.xml; None until an
+        # output dir has been read. The values above are only placeholders and
+        # self.xmin, etc. later track the Config tab, which need not describe the
+        # output being plotted, so plot_svg() maps .svg coords with these instead.
+        self.output_xmin = None
+        self.output_xmax = None
+        self.output_ymin = None
+        self.output_ymax = None
+
         self.aspect_ratio = 0.7
 
         self.view_aspect_square = True
@@ -2225,6 +2234,14 @@ class VisBase():
         self.plot_ymin = self.ymin
         self.plot_ymax = self.ymax
 
+        # PhysiCell writes cell centers in the .svg files relative to the lower
+        # corner of this domain, so keep it for plot_svg(); self.xmin, etc. get
+        # overwritten from the Config tab by reset_domain_box() below.
+        self.output_xmin = self.xmin
+        self.output_xmax = self.xmax
+        self.output_ymin = self.ymin
+        self.output_ymax = self.ymax
+
         self.zmin = float(bds[2])
         self.zmax = float(bds[5])
 
@@ -2304,6 +2321,12 @@ class VisBase():
         self.ymin = float(bds[1])
         self.ymax = float(bds[4])
         self.y_range = self.ymax - self.ymin
+
+        # rf. reset_model(): the frame of reference for the .svg cell coords
+        self.output_xmin = self.xmin
+        self.output_xmax = self.xmax
+        self.output_ymin = self.ymin
+        self.output_ymax = self.ymax
 
         # and plot 1st frame (.svg)
         self.current_svg_frame = 0

--- a/bin/vis_tab.py
+++ b/bin/vis_tab.py
@@ -429,6 +429,13 @@ class Vis(VisBase, QWidget):
             print("vis_tab.py: plot_svg(): Warning: full_fname not found: ",full_fname)
             return
 
+        if self.output_xmin is None:
+            # No output has been read yet, e.g. during startup when populating the
+            # substrates combobox replots before reset_model() has parsed
+            # initial.xml. Without the domain that produced this .svg there is
+            # nothing to map its coords into; reset_model() replots once it has one.
+            return
+
         self.title_str = ""
 
         xlist = deque()
@@ -467,6 +474,13 @@ class Vis(VisBase, QWidget):
                 break
             numChildren += 1
 
+        # PhysiCell freezes cells that wander out of the domain instead of removing
+        # them, so a cell center just outside it is legitimate. Pad the domain by its
+        # own width so the check below only rejects coords that could not be a cell
+        # position at all, e.g. from a partially written .svg.
+        x_pad = self.output_xmax - self.output_xmin
+        y_pad = self.output_ymax - self.output_ymin
+
         num_cells = 0
         if self.celltype_filter:
             # if the list is not empty, filter the cells
@@ -484,8 +498,8 @@ class Vis(VisBase, QWidget):
                 except:
                     continue
 
-                # map SVG coords into comp domain
-                xval = xval/self.x_range * self.x_range + self.xmin
+                # map SVG coords into the domain that produced them
+                xval += self.output_xmin
 
                 s = circle.attrib['fill']
                 if( s[0:4] == "rgba" ):
@@ -510,13 +524,13 @@ class Vis(VisBase, QWidget):
                     rgba = [1,1,1,1.0]
                     rgba[0:3] = [x for x in rgb_tuple]
 
-                # test for bogus x,y locations, i.e., outside the domain of the loaded output
-                if (xval < self.xmin) or (xval > self.xmax):
+                # test for bogus x,y locations
+                if (xval < self.output_xmin - x_pad) or (xval > self.output_xmax + x_pad):
                     print("bogus xval=", xval)
                     break
                 yval = float(circle.attrib['cy'])
-                yval = yval/self.y_range * self.y_range + self.ymin
-                if (yval < self.ymin) or (yval > self.ymax):
+                yval += self.output_ymin
+                if (yval < self.output_ymin - y_pad) or (yval > self.output_ymax + y_pad):
                     print("bogus yval=", yval)
                     break
 

--- a/bin/vis_tab_ecm.py
+++ b/bin/vis_tab_ecm.py
@@ -440,6 +440,13 @@ class Vis(VisBase, QWidget):
             print("vis_tab.py: plot_svg(): Warning: full_fname not found: ",full_fname)
             return
 
+        if self.output_xmin is None:
+            # No output has been read yet, e.g. during startup when populating the
+            # substrates combobox replots before reset_model() has parsed
+            # initial.xml. Without the domain that produced this .svg there is
+            # nothing to map its coords into; reset_model() replots once it has one.
+            return
+
         # self.ax0.cla()
         self.title_str = ""
 
@@ -517,6 +524,13 @@ class Vis(VisBase, QWidget):
                 break
             numChildren += 1
 
+        # PhysiCell freezes cells that wander out of the domain instead of removing
+        # them, so a cell center just outside it is legitimate. Pad the domain by its
+        # own width so the check below only rejects coords that could not be a cell
+        # position at all, e.g. from a partially written .svg.
+        x_pad = self.output_xmax - self.output_xmin
+        y_pad = self.output_ymax - self.output_ymin
+
         num_cells = 0
         #  print('------ search cells')
         for child in cells_parent:
@@ -527,9 +541,8 @@ class Vis(VisBase, QWidget):
                 #      print('  --- cx,cy=',circle.attrib['cx'],circle.attrib['cy'])
                 xval = float(circle.attrib['cx'])
 
-                # map SVG coords into comp domain
-                # xval = (xval-self.svg_xmin)/self.svg_xrange * self.x_range + self.xmin
-                xval = xval/self.x_range * self.x_range + self.xmin
+                # map SVG coords into the domain that produced them
+                xval += self.output_xmin
 
                 s = circle.attrib['fill']
                 # print("s=",s)
@@ -567,14 +580,13 @@ class Vis(VisBase, QWidget):
                     rgba = [1,1,1,1.0]
                     rgba[0:3] = [x for x in rgb_tuple]
 
-                # test for bogus x,y locations, i.e., outside the domain of the loaded output
-                if (xval < self.xmin) or (xval > self.xmax):
+                # test for bogus x,y locations
+                if (xval < self.output_xmin - x_pad) or (xval > self.output_xmax + x_pad):
                     print("bogus xval=", xval)
                     break
                 yval = float(circle.attrib['cy'])
-                # yval = (yval - self.svg_xmin)/self.svg_xrange * self.y_range + self.ymin
-                yval = yval/self.y_range * self.y_range + self.ymin
-                if (yval < self.ymin) or (yval > self.ymax):
+                yval += self.output_ymin
+                if (yval < self.output_ymin - y_pad) or (yval > self.output_ymax + y_pad):
                     print("bogus yval=", yval)
                     break
 


### PR DESCRIPTION
`plot_svg()` prints a `bogus xval=`/`bogus yval=` line for every cell and drops
each cell it prints for, starting as soon as Studio opens a project that already
has output:

```
---    cell_type (1)= None
bogus yval= 942.145
bogus xval= 517.495
bogus xval= 551.528
bogus xval= 826.3009999999999
bogus xval= 850.431
```

#365 replaced a hardcoded `+/-10000` bound with `self.xmin/xmax/ymin/ymax`, on
the assumption that those are the frame of reference the `.svg` coords were just
mapped into. They aren't, for two reasons.

**`plot_svg()` can run before any output has been read.** `studio.py` calls
`fill_substrates_combobox()` before `reset_model()`, and `QComboBox.addItem()`
emits `currentIndexChanged`, so the chain is

```
studio.py:434  fill_substrates_combobox()
  -> vis_base.py  substrates_combobox_changed_cb()
    -> vis_tab.py  update_plots()
      -> vis_tab.py  plot_svg()
```

The output dir is already set by then, so a `.svg` is found and parsed, but
`self.xmin/ymin` are still the placeholders from `VisBase.__init__()` —
`(-80, 80)` and `(-50, 100)`. That is exactly the console output above for a
`[-500,500]^2` model: `cx=597.495 - 80 = 517.495`, `cy=992.145 - 50 = 942.145`.
`reset_model()` runs a few lines later and replots correctly, which is why only
the prints were visible.

**The Config tab can disagree with the output.** Even after `reset_model()`
parses `initial.xml`, the `reset_domain_box()` call at the end of it overwrites
`self.xmin/xmax/ymin/ymax` from the Config tab. Plotting output whose domain
differs from the one currently being edited mapped and tested against the wrong
domain and discarded every cell.

## Change

PhysiCell writes each cell center into the `.svg` as `position - lower corner of
the mesh bounding box` of the run that produced it
(`standard_agent_SVG()` in `modules/PhysiCell_pathology.cpp`), so that domain —
not the Config tab's — is the only correct frame of reference. `reset_model()`
and `reset_axes()` now record it as `self.output_{x,y}{min,max}`, and
`plot_svg()` uses it for both the mapping and the bounds test.
`plot_svg()` returns early while it is still `None` (the startup case above);
`reset_model()` replots once there is a value.

```python
# before
xval = xval/self.x_range * self.x_range + self.xmin   # /x_range * x_range is a no-op
if (xval < self.xmin) or (xval > self.xmax):
    print("bogus xval=", xval)

# after
xval += self.output_xmin
if (xval < self.output_xmin - x_pad) or (xval > self.output_xmax + x_pad):
    print("bogus xval=", xval)
```

The test also gets a margin. `Cell::update_position()` freezes a cell that
leaves the domain (`is_out_of_domain = true; is_active = false;
is_movable = false`) rather than removing it, and `SVG_plot()` still draws it, so
a center slightly outside the domain is legitimate output. Padding by the
domain's own width keeps the check scaled to the model — the point of #365 —
while only rejecting coords that could not be a cell position at all.

The `ecm` variant of the Plot tab carries a copy of `plot_svg()` and gets the
same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
